### PR TITLE
Fix webhook dedup race window during node_id resolution

### DIFF
--- a/server.py
+++ b/server.py
@@ -365,8 +365,6 @@ def _make_handler(pat, passcode, allowed_file_keys, locale, model, claude_path,
             )
 
             if item is None:
-                with processed_lock:
-                    processed_ids.discard(comment_id)
                 logger.debug('skip', extra={'reason': reason})
                 self._respond(200, reason)
                 return


### PR DESCRIPTION
## Summary
- Remove `processed_ids.discard(comment_id)` for non-matching triggers, fixing a race where Figma retries arriving during slow `_build_work_item` calls could be permanently lost
- Non-matching comment IDs are now retained in `processed_ids` — cheap and eliminates the dedup/discard race entirely

Closes #11

## Test plan
- [x] Full test suite passes (162 tests)
- [x] Verify under load: duplicate webhooks for non-matching triggers are deduped on retry
- [x] Verify matching triggers still process normally