### PR TITLE
Fix 60s retry default and broad rate-limit detection

### DIFF
--- a/figwatch/providers/ai/__init__.py
+++ b/figwatch/providers/ai/__init__.py
@@ -85,7 +85,7 @@ class AIProvider(Protocol):
         ...
 
 
-def parse_retry_seconds(err, default=60):
+def parse_retry_seconds(err, default=5):
     """Extract suggested retry delay in seconds from a 429 error message."""
     m = re.search(r'retry[_\s]delay\D*?(\d+)|retry after (\d+)', str(err), re.IGNORECASE)
     if m:

--- a/figwatch/providers/ai/anthropic.py
+++ b/figwatch/providers/ai/anthropic.py
@@ -45,6 +45,6 @@ class AnthropicProvider:
             return response.content[0].text.strip()
 
         def _is_rate_limit(e):
-            return '429' in str(e) or 'rate' in str(e).lower() or 'RateLimitError' in type(e).__name__
+            return 'RateLimitError' in type(e).__name__ or '429' in str(e)
 
         return with_retry(_call, _is_rate_limit, 'anthropic')

--- a/tests/test_providers_ai.py
+++ b/tests/test_providers_ai.py
@@ -115,7 +115,7 @@ def test_parse_retry_seconds_retry_after_format():
 
 
 def test_parse_retry_seconds_no_hint_uses_default():
-    assert parse_retry_seconds("something went wrong") == 60
+    assert parse_retry_seconds("something went wrong") == 5
 
 
 def test_parse_retry_seconds_custom_default():


### PR DESCRIPTION
## Summary
- Lower `parse_retry_seconds` default from 60s to 5s — prevents unnecessary worker stalls when error message contains no retry hint
- Tighten Anthropic `_is_rate_limit` check: removed `'rate' in str(e).lower()` substring match that false-positived on errors containing words like "inaccurate" or "moderate". Now matches `RateLimitError` type name and `429` status only
- Gemini check (`'429'` + `'quota'`) left as-is — already specific enough

## Test plan
- [x] All 23 existing tests pass
- [ ] Verify retry behavior with actual 429 from Anthropic API
- [ ] Verify non-rate-limit errors containing "rate" no longer trigger retry sleep

Closes #12