### PR TITLE
Fix CI publish job running on workflow cancellation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
     # check-version is skipped on PRs; allow publish to proceed when its
     # needed jobs either succeeded or were intentionally skipped.
     if: |
-      always() &&
+      !cancelled() &&
       needs.test.result == 'success' &&
       needs.docker.result == 'success' &&
       (needs.check-version.result == 'success' || needs.check-version.result == 'skipped')


### PR DESCRIPTION
## Summary
- Replace `always()` with `!cancelled()` in the publish job's `if` condition
- Prevents cancelled workflows from pushing container images unintentionally

Closes #13

## Test plan
- [x] Verify CI passes on this PR
- [ ] Confirm publish job is skipped when workflow is cancelled