### PR TITLE
Bound processed_ids to prevent unbounded memory growth

### DIFF
--- a/figwatch/watcher.py
+++ b/figwatch/watcher.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import threading
+from collections import OrderedDict
 
 from figwatch.domain import WorkItem, load_trigger_config, match_trigger
 from figwatch.processor import process_work_item
@@ -13,6 +14,42 @@ logger = logging.getLogger(__name__)
 
 _EM_DASH = '\u2014'
 _OWN_REPLY_MARKERS = (_EM_DASH + ' Claude', _EM_DASH + ' Gemini')
+
+_PROCESSED_MAXLEN = 500
+
+
+# ── Bounded set ───────────────────────────────────────────────────────
+
+class BoundedSet:
+    """Set with a maximum size. Oldest entries evicted on overflow."""
+
+    def __init__(self, maxlen=_PROCESSED_MAXLEN):
+        self._maxlen = maxlen
+        self._data = OrderedDict()
+
+    def add(self, item):
+        if item in self._data:
+            self._data.move_to_end(item)
+            return
+        if len(self._data) >= self._maxlen:
+            self._data.popitem(last=False)
+        self._data[item] = None
+
+    def __contains__(self, item):
+        return item in self._data
+
+    def __len__(self):
+        return len(self._data)
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def update(self, items):
+        for item in items:
+            self.add(item)
+
+    def clear(self):
+        self._data.clear()
 
 
 # ── Processed comment tracking ────────────────────────────────────────
@@ -33,19 +70,17 @@ def _processed_path():
 def load_processed():
     try:
         with open(_processed_path()) as f:
-            return set(json.load(f))
+            ids = json.load(f)
+            bounded = BoundedSet()
+            bounded.update(ids)
+            return bounded
     except Exception:
-        return set()
+        return BoundedSet()
 
 
 def save_processed(ids):
-    id_list = list(ids)
-    if len(id_list) > 500:
-        id_list = id_list[-500:]
-        ids.clear()
-        ids.update(id_list)
     with open(_processed_path(), 'w') as f:
-        json.dump(id_list, f)
+        json.dump(list(ids), f)
 
 
 # ── Trigger detection (fast path — 1 API call) ────────────────────────

--- a/tests/test_bounded_set.py
+++ b/tests/test_bounded_set.py
@@ -1,0 +1,94 @@
+"""Tests for BoundedSet and processed-comment persistence."""
+
+import json
+import os
+import tempfile
+from unittest import mock
+
+from figwatch.watcher import BoundedSet, load_processed, save_processed
+
+
+class TestBoundedSet:
+    def test_add_and_contains(self):
+        s = BoundedSet(maxlen=5)
+        s.add('a')
+        s.add('b')
+        assert 'a' in s
+        assert 'b' in s
+        assert 'c' not in s
+
+    def test_evicts_oldest_on_overflow(self):
+        s = BoundedSet(maxlen=3)
+        s.add('a')
+        s.add('b')
+        s.add('c')
+        s.add('d')  # evicts 'a'
+        assert 'a' not in s
+        assert 'b' in s
+        assert 'd' in s
+        assert len(s) == 3
+
+    def test_add_existing_refreshes(self):
+        s = BoundedSet(maxlen=3)
+        s.add('a')
+        s.add('b')
+        s.add('c')
+        s.add('a')  # refresh — 'a' moves to end, 'b' is now oldest
+        s.add('d')  # evicts 'b'
+        assert 'a' in s
+        assert 'b' not in s
+        assert len(s) == 3
+
+    def test_iter_preserves_order(self):
+        s = BoundedSet(maxlen=5)
+        s.add('x')
+        s.add('y')
+        s.add('z')
+        assert list(s) == ['x', 'y', 'z']
+
+    def test_update(self):
+        s = BoundedSet(maxlen=3)
+        s.update(['a', 'b', 'c', 'd'])
+        assert 'a' not in s
+        assert list(s) == ['b', 'c', 'd']
+
+    def test_clear(self):
+        s = BoundedSet(maxlen=5)
+        s.update(['a', 'b'])
+        s.clear()
+        assert len(s) == 0
+        assert 'a' not in s
+
+
+class TestPersistence:
+    def test_load_save_roundtrip(self, tmp_path):
+        proc_file = tmp_path / '.processed-comments.json'
+        with mock.patch('figwatch.watcher._processed_path', return_value=str(proc_file)):
+            ids = BoundedSet()
+            ids.update(['1', '2', '3'])
+            save_processed(ids)
+
+            loaded = load_processed()
+            assert '1' in loaded
+            assert '2' in loaded
+            assert '3' in loaded
+            assert len(loaded) == 3
+
+    def test_load_missing_file(self, tmp_path):
+        missing = str(tmp_path / 'nope.json')
+        with mock.patch('figwatch.watcher._processed_path', return_value=missing):
+            loaded = load_processed()
+            assert len(loaded) == 0
+            assert isinstance(loaded, BoundedSet)
+
+    def test_save_respects_maxlen(self, tmp_path):
+        proc_file = tmp_path / '.processed-comments.json'
+        with mock.patch('figwatch.watcher._processed_path', return_value=str(proc_file)):
+            ids = BoundedSet(maxlen=3)
+            ids.update(['a', 'b', 'c', 'd', 'e'])
+            save_processed(ids)
+
+            with open(proc_file) as f:
+                on_disk = json.load(f)
+            assert len(on_disk) == 3
+            assert on_disk == ['c', 'd', 'e']


### PR DESCRIPTION
## Summary
- Replace plain `set()` with `BoundedSet` (OrderedDict-backed, maxlen=500) for webhook dedup
- Oldest entries evicted on overflow — memory stays constant regardless of uptime
- `save_processed` simplified since `BoundedSet` already enforces the cap
- 9 new tests covering eviction, refresh-on-re-add, persistence roundtrip

Closes #9

## Test plan
- [x] `BoundedSet` evicts oldest entry when maxlen exceeded
- [x] Re-adding existing entry refreshes its position (won't be evicted prematurely)
- [x] `load_processed` / `save_processed` roundtrip preserves entries
- [x] Missing file returns empty `BoundedSet`
- [x] Full test suite passes (171/171)