### PR TITLE
Make custom-skills dir configurable via FIGWATCH_SKILLS_DIR

### DIFF
--- a/figwatch/domain.py
+++ b/figwatch/domain.py
@@ -29,12 +29,16 @@ DEFAULT_TRIGGERS = [
 ]
 
 
-def _discover_custom_triggers():
-    """Scan ./custom-skills/ for .md files and return trigger entries.
+def _discover_custom_triggers(skills_dir=None):
+    """Scan custom-skills directory for .md files and return trigger entries.
 
     Supports flat files (a11y.md → @a11y) and subdirectories (a11y/skill.md → @a11y).
+
+    Args:
+        skills_dir: Path to the custom-skills directory. Defaults to
+                    ``os.getcwd() / 'custom-skills'`` when *None*.
     """
-    custom_dir = Path(os.getcwd()) / 'custom-skills'
+    custom_dir = Path(skills_dir) if skills_dir else Path(os.getcwd()) / 'custom-skills'
     if not custom_dir.is_dir():
         return []
 
@@ -61,16 +65,21 @@ def _discover_custom_triggers():
     return triggers
 
 
-def load_trigger_config():
+def load_trigger_config(skills_dir=None):
     """Load trigger config from config file or built-in defaults, plus any custom skills.
 
     Priority:
       1. ~/.figwatch/config.json  (written by the macOS app)
       2. Built-in defaults        (@tone, @ux)
 
-    In both cases, any .md files found in ./custom-skills/ are appended automatically.
+    In both cases, any .md files found in the custom-skills directory are appended
+    automatically.
+
+    Args:
+        skills_dir: Path to the custom-skills directory. Passed through to
+                    :func:`_discover_custom_triggers`.
     """
-    custom = _discover_custom_triggers()
+    custom = _discover_custom_triggers(skills_dir)
 
     try:
         config_path = os.path.join(os.path.expanduser('~'), '.figwatch', 'config.json')

--- a/server.py
+++ b/server.py
@@ -31,6 +31,7 @@ Environment variables:
   FIGWATCH_ANTHROPIC_RPM      Requests per minute for Anthropic (default: 5; 0 disables)
   FIGWATCH_LOG_LEVEL          Log level: DEBUG, INFO, WARNING, ERROR (default: INFO)
   FIGWATCH_LOG_FORMAT         Log format: text (default) or json
+  FIGWATCH_SKILLS_DIR         Path to custom-skills directory (default: ./custom-skills)
 
   Webhook health monitoring (all optional):
   OTEL_EXPORTER_OTLP_ENDPOINT   OTel collector endpoint (metrics disabled if unset)
@@ -459,9 +460,15 @@ def main():
     queue_update_rpm = int(os.environ.get('FIGWATCH_QUEUE_UPDATE_RPM', '5'))
     claude_path = 'api'
 
+    skills_dir = os.environ.get('FIGWATCH_SKILLS_DIR', '').strip() or None
+    if skills_dir and not os.path.isdir(skills_dir):
+        logger.error('FIGWATCH_SKILLS_DIR does not exist or is not a directory',
+                      extra={'path': skills_dir})
+        sys.exit(1)
+
     init_metrics()
 
-    trigger_config = load_trigger_config()
+    trigger_config = load_trigger_config(skills_dir)
     triggers_str = ', '.join(t.get('trigger', '') for t in trigger_config)
 
     processed_ids = load_processed()

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -7,6 +7,7 @@ import pytest
 from figwatch.domain import (
     DEFAULT_TRIGGERS,
     WorkItem,
+    _discover_custom_triggers,
     load_trigger_config,
     match_trigger,
 )
@@ -99,6 +100,33 @@ def test_load_trigger_config_custom_skill_subdir(tmp_path, monkeypatch):
 
     config = load_trigger_config()
     assert any(t["trigger"] == "@motion" for t in config)
+
+
+# ── FIGWATCH_SKILLS_DIR ─────────────────────────────────────────────
+
+def test_discover_custom_triggers_explicit_dir(tmp_path):
+    skills = tmp_path / "my-skills"
+    skills.mkdir()
+    (skills / "perf.md").write_text("# Perf skill")
+
+    triggers = _discover_custom_triggers(str(skills))
+    assert any(t["trigger"] == "@perf" for t in triggers)
+
+
+def test_load_trigger_config_with_skills_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    skills = tmp_path / "my-skills"
+    skills.mkdir()
+    (skills / "perf.md").write_text("# Perf skill")
+
+    config = load_trigger_config(skills_dir=str(skills))
+    assert any(t["trigger"] == "@perf" for t in config)
+
+
+def test_discover_custom_triggers_explicit_dir_missing(tmp_path):
+    """Non-existent explicit dir returns empty (caller validates at startup)."""
+    triggers = _discover_custom_triggers(str(tmp_path / "nope"))
+    assert triggers == []
 
 
 # ── WorkItem ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `_discover_custom_triggers` and `load_trigger_config` now accept an optional `skills_dir` parameter, falling back to `os.getcwd() / 'custom-skills'` when unset
- `server.py` reads `FIGWATCH_SKILLS_DIR` env var and validates it exists at startup (fail-fast per ADR-001)
- macOS app is unaffected — it calls `load_trigger_config()` without args, so behaviour is unchanged (uses cwd fallback)

## Test plan
- [x] New tests: explicit dir, explicit dir via `load_trigger_config`, missing dir returns empty
- [x] All 174 existing tests pass

Closes #14