### PR TITLE
Fix Dockerfile layer caching: install deps before copying source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl && \
 WORKDIR /app
 
 COPY pyproject.toml .
-COPY figwatch/__init__.py ./figwatch/__init__.py
-RUN pip install --no-cache-dir ".[server]"
 COPY figwatch/ ./figwatch/
 COPY server.py .
+RUN pip install --no-cache-dir ".[server]"
 
 VOLUME ["/app/custom-skills"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl && \
 WORKDIR /app
 
 COPY pyproject.toml .
+COPY figwatch/__init__.py ./figwatch/__init__.py
+RUN pip install --no-cache-dir ".[server]"
 COPY figwatch/ ./figwatch/
 COPY server.py .
-RUN pip install --no-cache-dir ".[server]"
 
 VOLUME ["/app/custom-skills"]
 

--- a/figwatch/logging_config.py
+++ b/figwatch/logging_config.py
@@ -83,11 +83,15 @@ class TextFormatter(logging.Formatter):
                 ctx_parts.append(f'{key}={ctx[key]}')
         ctx_str = (' '.join(ctx_parts) + ' ') if ctx_parts else ''
 
-        # Only emit known FigWatch extra= fields, ignoring third-party attrs.
+        # Any extra= fields attached directly to the record, excluding the
+        # standard LogRecord attrs and our own context dict.
         extra_parts = []
-        for key in _KNOWN_EXTRA_KEYS:
-            if key in record.__dict__ and key not in ctx:
-                extra_parts.append(f'{key}={record.__dict__[key]}')
+        for key, value in record.__dict__.items():
+            if key in _STD_RECORD_ATTRS or key == 'audit_context':
+                continue
+            if key in ctx:
+                continue
+            extra_parts.append(f'{key}={value}')
         extra_str = (' '.join(extra_parts) + ' ') if extra_parts else ''
 
         msg = record.getMessage()
@@ -118,9 +122,12 @@ class JsonFormatter(logging.Formatter):
         ctx = getattr(record, 'audit_context', {}) or {}
         payload.update(ctx)
 
-        for key in _KNOWN_EXTRA_KEYS:
-            if key in record.__dict__ and key not in payload:
-                payload[key] = record.__dict__[key]
+        for key, value in record.__dict__.items():
+            if key in _STD_RECORD_ATTRS or key == 'audit_context':
+                continue
+            if key in payload:
+                continue
+            payload[key] = value
 
         if record.exc_info:
             payload['exc'] = self.formatException(record.exc_info)
@@ -134,13 +141,6 @@ _STD_RECORD_ATTRS = frozenset({
     'module', 'exc_info', 'exc_text', 'stack_info', 'lineno', 'funcName',
     'created', 'msecs', 'relativeCreated', 'thread', 'threadName',
     'processName', 'process', 'message', 'taskName',
-})
-
-# Extra keys explicitly used by FigWatch via logger.xxx(..., extra={key: val}).
-# Only these are emitted as extras — third-party attributes are ignored.
-_KNOWN_EXTRA_KEYS = frozenset({
-    'ack_id', 'chars', 'depth', 'endpoint', 'error', 'reason',
-    'reply_to', 'skill',
 })
 
 

--- a/figwatch/logging_config.py
+++ b/figwatch/logging_config.py
@@ -83,15 +83,11 @@ class TextFormatter(logging.Formatter):
                 ctx_parts.append(f'{key}={ctx[key]}')
         ctx_str = (' '.join(ctx_parts) + ' ') if ctx_parts else ''
 
-        # Any extra= fields attached directly to the record, excluding the
-        # standard LogRecord attrs and our own context dict.
+        # Only emit known FigWatch extra= fields, ignoring third-party attrs.
         extra_parts = []
-        for key, value in record.__dict__.items():
-            if key in _STD_RECORD_ATTRS or key == 'audit_context':
-                continue
-            if key in ctx:
-                continue
-            extra_parts.append(f'{key}={value}')
+        for key in _KNOWN_EXTRA_KEYS:
+            if key in record.__dict__ and key not in ctx:
+                extra_parts.append(f'{key}={record.__dict__[key]}')
         extra_str = (' '.join(extra_parts) + ' ') if extra_parts else ''
 
         msg = record.getMessage()
@@ -122,12 +118,9 @@ class JsonFormatter(logging.Formatter):
         ctx = getattr(record, 'audit_context', {}) or {}
         payload.update(ctx)
 
-        for key, value in record.__dict__.items():
-            if key in _STD_RECORD_ATTRS or key == 'audit_context':
-                continue
-            if key in payload:
-                continue
-            payload[key] = value
+        for key in _KNOWN_EXTRA_KEYS:
+            if key in record.__dict__ and key not in payload:
+                payload[key] = record.__dict__[key]
 
         if record.exc_info:
             payload['exc'] = self.formatException(record.exc_info)
@@ -141,6 +134,13 @@ _STD_RECORD_ATTRS = frozenset({
     'module', 'exc_info', 'exc_text', 'stack_info', 'lineno', 'funcName',
     'created', 'msecs', 'relativeCreated', 'thread', 'threadName',
     'processName', 'process', 'message', 'taskName',
+})
+
+# Extra keys explicitly used by FigWatch via logger.xxx(..., extra={key: val}).
+# Only these are emitted as extras — third-party attributes are ignored.
+_KNOWN_EXTRA_KEYS = frozenset({
+    'ack_id', 'chars', 'depth', 'endpoint', 'error', 'reason',
+    'reply_to', 'skill',
 })
 
 


### PR DESCRIPTION
## Summary
- Reorder Dockerfile layers so `pip install` runs before source copy — only `pyproject.toml` + `__init__.py` (needed for version attr) are copied first, so source changes no longer invalidate the dependency cache layer.

Closes #15

## Test plan
- [ ] Docker build — verify cache hit on `pip install` layer when only source files change