### PR TITLE
Adopt Domain-Driven Design per ADR-002

### DIFF
--- a/figwatch/ack_updater.py
+++ b/figwatch/ack_updater.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 from typing import Dict, Optional
 
 from figwatch.log_context import set_audit_context, reset_audit_context
-from figwatch.processor import post_ack, delete_ack
+from figwatch.ports import CommentRepository
 from figwatch.providers.ai.rate_limit import TokenBucket
 from figwatch.queue_stats import InstrumentedQueue, QueuedItem
 
@@ -57,10 +57,12 @@ class AckUpdater:
     def __init__(
         self,
         work_queue: InstrumentedQueue,
+        comment_repo: CommentRepository,
         rate_per_minute: int = 5,
         poll_seconds: float = 2.0,
     ):
         self._queue = work_queue
+        self._comment_repo = comment_repo
         self._rate_per_minute = rate_per_minute
         self._poll_seconds = poll_seconds
         # Maps audit_id → last-posted position. An audit with no entry here
@@ -189,17 +191,28 @@ class AckUpdater:
                          extra={'audit': update.audit_id})
             return
 
+        audit = queued.audit
+        trigger_kw = audit.trigger_match.trigger.keyword
+        file_key = audit.comment.file_key
+        node_id = audit.comment.node_id
+
         token = set_audit_context(
             audit=update.audit_id,
-            trigger=queued.item.trigger,
-            node=queued.item.node_id,
-            file=queued.item.file_key,
+            trigger=trigger_kw,
+            node=node_id,
+            file=file_key,
         )
         try:
-            new_message = _position_message(queued.item.trigger, update.new_position)
+            new_message = _position_message(trigger_kw, update.new_position)
             old_ack_id = queued.ack_id
-            delete_ack(queued.item, old_ack_id)
-            new_ack_id = post_ack(queued.item, new_message)
+
+            # Delete old ack, post new one
+            if old_ack_id:
+                self._comment_repo.delete_comment(file_key, old_ack_id)
+            new_ack_id = self._comment_repo.post_reply(
+                file_key, audit.reply_to_id, new_message,
+            )
+
             # Write the new ack_id back onto the QueuedItem so the worker
             # picks it up when/if it dequeues. If the worker dequeued
             # concurrently, this write is to a detached object — harmless.
@@ -212,5 +225,3 @@ class AckUpdater:
             logger.exception('ack update post failed')
         finally:
             reset_audit_context(token)
-
-

--- a/figwatch/domain.py
+++ b/figwatch/domain.py
@@ -19,13 +19,7 @@ class AuditStatus(Enum):
     ERROR = 'error'
 
 
-# Deprecated — use AuditStatus enum. Kept for backward compatibility
-# with processor.py and macos/FigWatch.py until Phase 4.
 STATUS_LIVE = 'live'
-STATUS_DETECTED = AuditStatus.DETECTED.value
-STATUS_PROCESSING = AuditStatus.PROCESSING.value
-STATUS_REPLIED = AuditStatus.REPLIED.value
-STATUS_ERROR = AuditStatus.ERROR.value
 
 
 # ── Value objects (frozen) ───────────────────────────────────────────
@@ -125,17 +119,6 @@ class Audit:
     def collect_events(self) -> list:
         events, self._events = self._events, []
         return events
-
-
-# ── WorkItem (deprecated — use Audit) ───────────────────────────────
-
-from collections import namedtuple  # noqa: E402
-
-WorkItem = namedtuple('WorkItem', [
-    'file_key', 'comment_id', 'reply_to_id', 'node_id',
-    'trigger', 'skill_path', 'user_handle', 'extra',
-    'locale', 'model', 'reply_lang', 'pat', 'claude_path', 'on_status',
-])
 
 
 # ── Pure domain functions ────────────────────────────────────────────

--- a/figwatch/domain.py
+++ b/figwatch/domain.py
@@ -1,19 +1,135 @@
-"""FigWatch domain types and trigger configuration."""
+"""FigWatch domain types — pure module, no I/O.
 
-import json
-import os
-from collections import namedtuple
-from pathlib import Path
+Defines the Audit aggregate root, value objects, domain events,
+and the AuditStatus enum for the Comment Auditing bounded context.
+"""
 
-# ── Status constants ──────────────────────────────────────────────────
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Optional
 
+
+# ── Audit status ─────────────────────────────────────────────────────
+
+class AuditStatus(Enum):
+    DETECTED = 'detected'
+    QUEUED = 'queued'
+    PROCESSING = 'processing'
+    REPLIED = 'replied'
+    ERROR = 'error'
+
+
+# Deprecated — use AuditStatus enum. Kept for backward compatibility
+# with processor.py and macos/FigWatch.py until Phase 4.
 STATUS_LIVE = 'live'
-STATUS_DETECTED = 'detected'
-STATUS_PROCESSING = 'processing'
-STATUS_REPLIED = 'replied'
-STATUS_ERROR = 'error'
+STATUS_DETECTED = AuditStatus.DETECTED.value
+STATUS_PROCESSING = AuditStatus.PROCESSING.value
+STATUS_REPLIED = AuditStatus.REPLIED.value
+STATUS_ERROR = AuditStatus.ERROR.value
 
-# ── WorkItem ──────────────────────────────────────────────────────────
+
+# ── Value objects (frozen) ───────────────────────────────────────────
+
+@dataclass(frozen=True)
+class Trigger:
+    keyword: str       # e.g. "@ux"
+    skill_ref: str     # e.g. "builtin:ux" or "/path/to/skill.md"
+
+
+@dataclass(frozen=True)
+class TriggerMatch:
+    trigger: Trigger
+    extra: str         # additional context after the trigger word
+
+
+@dataclass(frozen=True)
+class Comment:
+    comment_id: str
+    message: str
+    parent_id: Optional[str]
+    node_id: Optional[str]
+    user_handle: str
+    file_key: str
+
+
+@dataclass(frozen=True)
+class AuditResult:
+    reply_text: str
+    provider_name: str
+    frame_name: str
+
+
+# ── Domain events (frozen) ──────────────────────────────────────────
+
+@dataclass(frozen=True)
+class TriggerDetected:
+    audit_id: str
+    trigger_keyword: str
+    file_key: str
+    node_id: str
+
+
+@dataclass(frozen=True)
+class AuditQueued:
+    audit_id: str
+
+
+@dataclass(frozen=True)
+class AuditStarted:
+    audit_id: str
+
+
+@dataclass(frozen=True)
+class AuditCompleted:
+    audit_id: str
+    result: AuditResult
+
+
+@dataclass(frozen=True)
+class AuditFailed:
+    audit_id: str
+    error: str
+
+
+# ── Audit aggregate root ────────────────────────────────────────────
+
+@dataclass
+class Audit:
+    """Aggregate root — one per trigger comment detected."""
+    audit_id: str
+    comment: Comment
+    trigger_match: TriggerMatch
+    status: AuditStatus = AuditStatus.DETECTED
+    _events: List = field(default_factory=list, repr=False)
+
+    @property
+    def reply_to_id(self) -> str:
+        return self.comment.parent_id or self.comment.comment_id
+
+    def queue(self):
+        self.status = AuditStatus.QUEUED
+        self._events.append(AuditQueued(self.audit_id))
+
+    def start_processing(self):
+        self.status = AuditStatus.PROCESSING
+        self._events.append(AuditStarted(self.audit_id))
+
+    def complete(self, result: AuditResult):
+        self.status = AuditStatus.REPLIED
+        self._events.append(AuditCompleted(self.audit_id, result))
+
+    def fail(self, error: str):
+        self.status = AuditStatus.ERROR
+        self._events.append(AuditFailed(self.audit_id, error))
+
+    def collect_events(self) -> list:
+        events, self._events = self._events, []
+        return events
+
+
+# ── WorkItem (deprecated — use Audit) ───────────────────────────────
+
+from collections import namedtuple  # noqa: E402
 
 WorkItem = namedtuple('WorkItem', [
     'file_key', 'comment_id', 'reply_to_id', 'node_id',
@@ -21,87 +137,13 @@ WorkItem = namedtuple('WorkItem', [
     'locale', 'model', 'reply_lang', 'pat', 'claude_path', 'on_status',
 ])
 
-# ── Trigger config ────────────────────────────────────────────────────
 
-DEFAULT_TRIGGERS = [
-    {"trigger": "@tone", "skill": "builtin:tone"},
-    {"trigger": "@ux", "skill": "builtin:ux"},
-]
-
-
-def _discover_custom_triggers(skills_dir=None):
-    """Scan custom-skills directory for .md files and return trigger entries.
-
-    Supports flat files (a11y.md → @a11y) and subdirectories (a11y/skill.md → @a11y).
-
-    Args:
-        skills_dir: Path to the custom-skills directory. Defaults to
-                    ``os.getcwd() / 'custom-skills'`` when *None*.
-    """
-    custom_dir = Path(skills_dir) if skills_dir else Path(os.getcwd()) / 'custom-skills'
-    if not custom_dir.is_dir():
-        return []
-
-    triggers = []
-    seen = set()
-
-    for path in sorted(custom_dir.glob('*.md')):
-        name = path.stem
-        if name not in seen:
-            seen.add(name)
-            triggers.append({'trigger': f'@{name}', 'skill': str(path.resolve())})
-
-    for skill_dir in sorted(p for p in custom_dir.iterdir() if p.is_dir()):
-        name = skill_dir.name
-        if name in seen:
-            continue
-        for fname in ['skill.md', 'SKILL.md']:
-            skill_path = skill_dir / fname
-            if skill_path.exists():
-                seen.add(name)
-                triggers.append({'trigger': f'@{name}', 'skill': str(skill_path.resolve())})
-                break
-
-    return triggers
-
-
-def load_trigger_config(skills_dir=None):
-    """Load trigger config from config file or built-in defaults, plus any custom skills.
-
-    Priority:
-      1. ~/.figwatch/config.json  (written by the macOS app)
-      2. Built-in defaults        (@tone, @ux)
-
-    In both cases, any .md files found in the custom-skills directory are appended
-    automatically.
-
-    Args:
-        skills_dir: Path to the custom-skills directory. Passed through to
-                    :func:`_discover_custom_triggers`.
-    """
-    custom = _discover_custom_triggers(skills_dir)
-
-    try:
-        config_path = os.path.join(os.path.expanduser('~'), '.figwatch', 'config.json')
-        with open(config_path) as f:
-            config = json.load(f)
-        triggers = config.get('triggers')
-        if triggers and isinstance(triggers, list):
-            existing = {t.get('trigger') for t in triggers}
-            for t in custom:
-                if t['trigger'] not in existing:
-                    triggers.append(t)
-            return triggers
-    except Exception:
-        pass
-
-    return list(DEFAULT_TRIGGERS) + custom
-
+# ── Pure domain functions ────────────────────────────────────────────
 
 def match_trigger(message, trigger_config):
     """Match a comment message against configured triggers.
 
-    Returns {"trigger": str, "skill": str, "extra": str} or None.
+    Returns a TriggerMatch or None.
     """
     lower = message.lower().strip()
     for entry in trigger_config:
@@ -109,5 +151,8 @@ def match_trigger(message, trigger_config):
         if trigger and trigger.lower() in lower:
             idx = lower.index(trigger.lower())
             extra = message[idx + len(trigger):].strip()
-            return {'trigger': trigger, 'skill': entry.get('skill', ''), 'extra': extra}
+            return TriggerMatch(
+                trigger=Trigger(keyword=trigger, skill_ref=entry.get('skill', '')),
+                extra=extra,
+            )
     return None

--- a/figwatch/domain.py
+++ b/figwatch/domain.py
@@ -6,7 +6,7 @@ and the AuditStatus enum for the Comment Auditing bounded context.
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Optional
+from typing import List, Optional, Union
 
 
 # ── Audit status ─────────────────────────────────────────────────────
@@ -49,8 +49,6 @@ class Comment:
 @dataclass(frozen=True)
 class AuditResult:
     reply_text: str
-    provider_name: str
-    frame_name: str
 
 
 # ── Domain events (frozen) ──────────────────────────────────────────
@@ -85,6 +83,9 @@ class AuditFailed:
     error: str
 
 
+DomainEvent = Union[TriggerDetected, AuditQueued, AuditStarted, AuditCompleted, AuditFailed]
+
+
 # ── Audit aggregate root ────────────────────────────────────────────
 
 @dataclass
@@ -94,7 +95,7 @@ class Audit:
     comment: Comment
     trigger_match: TriggerMatch
     status: AuditStatus = AuditStatus.DETECTED
-    _events: List = field(default_factory=list, repr=False)
+    _events: List[DomainEvent] = field(default_factory=list, repr=False)
 
     @property
     def reply_to_id(self) -> str:

--- a/figwatch/ports.py
+++ b/figwatch/ports.py
@@ -1,0 +1,32 @@
+"""Repository protocols — ports for infrastructure access.
+
+Structural (duck-typed) protocols. Implementations live in providers/.
+"""
+
+from typing import Optional, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class CommentRepository(Protocol):
+    """Port for reading and writing Figma comments."""
+
+    def post_reply(self, file_key: str, parent_comment_id: str, message: str) -> Optional[str]:
+        """Post a comment reply. Returns comment ID or None on failure."""
+        ...
+
+    def delete_comment(self, file_key: str, comment_id: str) -> None:
+        """Delete a comment. Silent on failure."""
+        ...
+
+    def fetch_comments(self, file_key: str) -> list:
+        """Fetch all comments for a file."""
+        ...
+
+
+@runtime_checkable
+class DesignDataRepository(Protocol):
+    """Port for fetching Figma design data needed by skills."""
+
+    def fetch(self, required_data: list, file_key: str, node_id: str) -> tuple:
+        """Fetch design data. Returns (data_dict, tree_data)."""
+        ...

--- a/figwatch/ports.py
+++ b/figwatch/ports.py
@@ -3,7 +3,7 @@
 Structural (duck-typed) protocols. Implementations live in providers/.
 """
 
-from typing import Optional, Protocol, runtime_checkable
+from typing import Any, Optional, Protocol, runtime_checkable
 
 
 @runtime_checkable
@@ -11,7 +11,7 @@ class CommentRepository(Protocol):
     """Port for reading and writing Figma comments."""
 
     def post_reply(self, file_key: str, parent_comment_id: str, message: str) -> Optional[str]:
-        """Post a comment reply. Returns comment ID or None on failure."""
+        """Post a comment reply. Returns comment ID. Raises on failure."""
         ...
 
     def delete_comment(self, file_key: str, comment_id: str) -> None:
@@ -27,6 +27,6 @@ class CommentRepository(Protocol):
 class DesignDataRepository(Protocol):
     """Port for fetching Figma design data needed by skills."""
 
-    def fetch(self, required_data: list, file_key: str, node_id: str) -> tuple:
-        """Fetch design data. Returns (data_dict, tree_data)."""
+    def fetch(self, required_data: list, file_key: str, node_id: str) -> tuple[dict, Optional[dict]]:
+        """Fetch design data. Returns (data_dict, tree_data_or_None)."""
         ...

--- a/figwatch/processor.py
+++ b/figwatch/processor.py
@@ -9,7 +9,8 @@ import logging
 import re
 from typing import Optional
 
-from figwatch.domain import STATUS_PROCESSING, STATUS_REPLIED, STATUS_ERROR, load_trigger_config
+from figwatch.domain import STATUS_PROCESSING, STATUS_REPLIED, STATUS_ERROR
+from figwatch.trigger_config import load_trigger_config
 from figwatch.providers.figma import figma_post, figma_delete
 
 logger = logging.getLogger(__name__)

--- a/figwatch/processor.py
+++ b/figwatch/processor.py
@@ -1,60 +1,11 @@
-"""Work item processing: ack → run skill → post reply.
+"""Reply formatting utilities."""
 
-Public helpers (post_ack, update_ack, delete_ack, clean_reply, post_reply) are
-used by both the macOS polling path (via process_work_item) and the server
-worker loop, which owns its own ack lifecycle for queue position + retry updates.
-"""
-
-import logging
 import re
-from typing import Optional
 
-from figwatch.domain import STATUS_PROCESSING, STATUS_REPLIED, STATUS_ERROR
 from figwatch.trigger_config import load_trigger_config
-from figwatch.providers.figma import figma_post, figma_delete
 
-logger = logging.getLogger(__name__)
-
-_EM_DASH = '\u2014'
 FIGMA_COMMENT_LIMIT = 4900
 
-
-# ── Ack lifecycle helpers ─────────────────────────────────────────────
-
-def post_ack(item, message: str) -> Optional[str]:
-    """Post an ack reply to the trigger comment. Returns ack_id or None on failure."""
-    try:
-        ack = figma_post(f'/files/{item.file_key}/comments', {
-            'message': message,
-            'comment_id': item.reply_to_id,
-        }, item.pat)
-        ack_id = ack.get('id')
-        logger.debug('ack posted', extra={'ack_id': ack_id})
-        return ack_id
-    except Exception as e:
-        logger.warning('ack post failed (non-fatal)', extra={'error': str(e)})
-        return None
-
-
-def delete_ack(item, ack_id: Optional[str]) -> None:
-    """Delete an ack comment. Silent if ack_id is None or delete fails."""
-    if not ack_id:
-        return
-    try:
-        figma_delete(f'/files/{item.file_key}/comments/{ack_id}', item.pat)
-        logger.debug('ack deleted', extra={'ack_id': ack_id})
-    except Exception as e:
-        logger.warning('ack delete failed (non-fatal)',
-                       extra={'ack_id': ack_id, 'error': str(e)})
-
-
-def update_ack(item, old_ack_id: Optional[str], message: str) -> Optional[str]:
-    """Replace an ack comment with a new one (Figma has no PUT). Returns the new ack_id."""
-    delete_ack(item, old_ack_id)
-    return post_ack(item, message)
-
-
-# ── Reply formatting + posting ────────────────────────────────────────
 
 def clean_reply(response: str, trigger_config=None) -> str:
     """Strip trigger words from reply to prevent feedback loops, then truncate."""
@@ -76,58 +27,3 @@ def clean_reply(response: str, trigger_config=None) -> str:
             truncated = truncated[:last_nl]
         response = truncated + f'\n\n(truncated \u2014 full audit was {total} chars)'
     return response
-
-
-def post_reply(item, message: str) -> None:
-    """Post a reply in the thread of the trigger comment."""
-    figma_post(f'/files/{item.file_key}/comments', {
-        'message': message,
-        'comment_id': item.reply_to_id,
-    }, item.pat)
-
-
-# ── macOS polling path (creates ack itself) ───────────────────────────
-
-def process_work_item(item, *, trigger_config=None):
-    """Post ack, execute skill, post reply. Used by the macOS polling path.
-
-    The server path uses the helpers above directly so it can manage ack lifecycle
-    across retries and queue position updates.
-
-    Returns True on success, False on failure (error reply posted to Figma).
-    """
-    from figwatch.skills import execute_skill
-
-    if item.on_status:
-        item.on_status(STATUS_PROCESSING, item)
-
-    ack_id = post_ack(
-        item,
-        f'\u23f3 {item.trigger.lstrip("@")} audit received \u2014 working on it\u2026',
-    )
-
-    try:
-        logger.info('running skill', extra={'skill': item.skill_path})
-        response = execute_skill(item)
-        logger.info('skill returned', extra={'chars': len(response)})
-
-        delete_ack(item, ack_id)
-        response = clean_reply(response, trigger_config)
-        post_reply(item, response)
-        logger.info('reply posted', extra={'reply_to': item.reply_to_id})
-
-        if item.on_status:
-            item.on_status(STATUS_REPLIED, item)
-        return True
-
-    except Exception as err:
-        logger.exception('skill execution failed')
-        delete_ack(item, ack_id)
-        try:
-            post_reply(item, f'Audit failed: {err}\n\n{_EM_DASH} FigWatch')
-            logger.info('error reply posted')
-        except Exception:
-            logger.exception('error reply post also failed')
-        if item.on_status:
-            item.on_status(STATUS_ERROR, item, error=str(err))
-        return False

--- a/figwatch/providers/figma.py
+++ b/figwatch/providers/figma.py
@@ -256,3 +256,42 @@ def fetch_figma_data(required_data, file_key, node_id, pat):
             result['annotations'] = _extract_annotations(tree_data)
 
     return result, tree_data
+
+
+# ── Repository implementations ───────────────────────────────────────
+
+class FigmaCommentRepository:
+    """CommentRepository implementation backed by the Figma REST API."""
+
+    def __init__(self, pat: str):
+        self._pat = pat
+
+    def post_reply(self, file_key: str, parent_comment_id: str, message: str):
+        try:
+            resp = figma_post(f'/files/{file_key}/comments', {
+                'message': message,
+                'comment_id': parent_comment_id,
+            }, self._pat)
+            return resp.get('id')
+        except Exception:
+            return None
+
+    def delete_comment(self, file_key: str, comment_id: str) -> None:
+        try:
+            figma_delete(f'/files/{file_key}/comments/{comment_id}', self._pat)
+        except Exception:
+            pass
+
+    def fetch_comments(self, file_key: str) -> list:
+        data = figma_get(f'/files/{file_key}/comments', self._pat)
+        return (data or {}).get('comments', [])
+
+
+class FigmaDesignDataRepository:
+    """DesignDataRepository implementation backed by the Figma REST API."""
+
+    def __init__(self, pat: str):
+        self._pat = pat
+
+    def fetch(self, required_data: list, file_key: str, node_id: str) -> tuple:
+        return fetch_figma_data(required_data, file_key, node_id, self._pat)

--- a/figwatch/providers/figma.py
+++ b/figwatch/providers/figma.py
@@ -267,14 +267,11 @@ class FigmaCommentRepository:
         self._pat = pat
 
     def post_reply(self, file_key: str, parent_comment_id: str, message: str):
-        try:
-            resp = figma_post(f'/files/{file_key}/comments', {
-                'message': message,
-                'comment_id': parent_comment_id,
-            }, self._pat)
-            return resp.get('id')
-        except Exception:
-            return None
+        resp = figma_post(f'/files/{file_key}/comments', {
+            'message': message,
+            'comment_id': parent_comment_id,
+        }, self._pat)
+        return resp.get('id')
 
     def delete_comment(self, file_key: str, comment_id: str) -> None:
         try:

--- a/figwatch/queue_stats.py
+++ b/figwatch/queue_stats.py
@@ -11,20 +11,16 @@ from typing import Any, List, Optional
 
 @dataclass
 class QueuedItem:
-    """Wrapper around a work item tracking queue/processing metadata.
+    """Wraps an Audit with queue/processing metadata.
 
     `ack_id` is mutable: the AckUpdater posts a new ack and writes the new
     ID back onto this object while the item is still in the queue. Workers
     only read ack_id after get() returns the item, at which point the
     updater is guaranteed to have stopped touching it (via cancel()).
-
-    During migration, both `item` (WorkItem) and `audit` (Audit) may be set.
-    Phase 4 removes `item` and makes `audit` the sole payload.
     """
-    item: Any
+    audit: Any
     ack_id: Optional[str]
     audit_id: str
-    audit: Any = None
     enqueued_at: float = field(default_factory=time.monotonic)
     attempt: int = 1
     waited_seconds: float = 0.0

--- a/figwatch/queue_stats.py
+++ b/figwatch/queue_stats.py
@@ -11,16 +11,20 @@ from typing import Any, List, Optional
 
 @dataclass
 class QueuedItem:
-    """Wrapper around a WorkItem tracking queue/processing metadata.
+    """Wrapper around a work item tracking queue/processing metadata.
 
     `ack_id` is mutable: the AckUpdater posts a new ack and writes the new
     ID back onto this object while the item is still in the queue. Workers
     only read ack_id after get() returns the item, at which point the
     updater is guaranteed to have stopped touching it (via cancel()).
+
+    During migration, both `item` (WorkItem) and `audit` (Audit) may be set.
+    Phase 4 removes `item` and makes `audit` the sole payload.
     """
     item: Any
     ack_id: Optional[str]
     audit_id: str
+    audit: Any = None
     enqueued_at: float = field(default_factory=time.monotonic)
     attempt: int = 1
     waited_seconds: float = 0.0

--- a/figwatch/services.py
+++ b/figwatch/services.py
@@ -1,0 +1,108 @@
+"""Application services — orchestration layer between domain and infrastructure."""
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from figwatch.domain import Audit, AuditCompleted, AuditFailed, AuditResult
+from figwatch.ports import CommentRepository, DesignDataRepository
+from figwatch.processor import clean_reply
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AuditConfig:
+    """Runtime configuration passed to skill execution — not domain state."""
+    model: str
+    claude_path: str
+    reply_lang: str
+    locale: str
+
+
+class AuditService:
+    """Coordinates audit execution using repositories and domain objects.
+
+    Receives repository implementations via constructor (dependency injection).
+    """
+
+    def __init__(
+        self,
+        comment_repo: CommentRepository,
+        design_repo: DesignDataRepository,
+        config: AuditConfig,
+        trigger_config: list,
+    ):
+        self._comments = comment_repo
+        self._design = design_repo
+        self._config = config
+        self._trigger_config = trigger_config
+
+    @property
+    def config(self) -> AuditConfig:
+        return self._config
+
+    @property
+    def design_repo(self) -> DesignDataRepository:
+        return self._design
+
+    def post_ack(self, audit: Audit, message: str) -> Optional[str]:
+        return self._comments.post_reply(
+            audit.comment.file_key,
+            audit.reply_to_id,
+            message,
+        )
+
+    def delete_ack(self, audit: Audit, ack_id: Optional[str]) -> None:
+        if not ack_id:
+            return
+        self._comments.delete_comment(audit.comment.file_key, ack_id)
+
+    def update_ack(self, audit: Audit, old_ack_id: Optional[str], message: str) -> Optional[str]:
+        self.delete_ack(audit, old_ack_id)
+        return self.post_ack(audit, message)
+
+    def post_reply(self, audit: Audit, message: str) -> None:
+        self._comments.post_reply(
+            audit.comment.file_key,
+            audit.reply_to_id,
+            message,
+        )
+
+    def execute(self, audit: Audit) -> str:
+        """Run skill for an audit. Returns cleaned reply string.
+
+        Calls audit.start_processing() / complete() / fail() to transition
+        status and emit domain events. Raises on failure after calling fail().
+        """
+        from figwatch.skills import execute_skill
+
+        audit.start_processing()
+
+        try:
+            response = execute_skill(
+                audit,
+                config=self._config,
+                design_repo=self._design,
+            )
+            cleaned = clean_reply(response, self._trigger_config)
+            audit.complete(AuditResult(
+                reply_text=cleaned,
+                provider_name='',  # embedded in response header by execute_skill
+                frame_name='',
+            ))
+            return cleaned
+        except Exception as err:
+            audit.fail(str(err))
+            raise
+
+    def dispatch_events(self, audit: Audit, duration: float) -> None:
+        """Collect and dispatch domain events for metrics/logging."""
+        from figwatch.metrics import record_audit_completed
+
+        events = audit.collect_events()
+        for event in events:
+            if isinstance(event, AuditCompleted):
+                record_audit_completed(duration, 'success')
+            elif isinstance(event, AuditFailed):
+                record_audit_completed(duration, 'failed')

--- a/figwatch/services.py
+++ b/figwatch/services.py
@@ -47,11 +47,15 @@ class AuditService:
         return self._design
 
     def post_ack(self, audit: Audit, message: str) -> Optional[str]:
-        return self._comments.post_reply(
-            audit.comment.file_key,
-            audit.reply_to_id,
-            message,
-        )
+        try:
+            return self._comments.post_reply(
+                audit.comment.file_key,
+                audit.reply_to_id,
+                message,
+            )
+        except Exception as e:
+            logger.warning('ack post failed (non-fatal)', extra={'error': str(e)})
+            return None
 
     def delete_ack(self, audit: Audit, ack_id: Optional[str]) -> None:
         if not ack_id:
@@ -86,11 +90,7 @@ class AuditService:
                 design_repo=self._design,
             )
             cleaned = clean_reply(response, self._trigger_config)
-            audit.complete(AuditResult(
-                reply_text=cleaned,
-                provider_name='',  # embedded in response header by execute_skill
-                frame_name='',
-            ))
+            audit.complete(AuditResult(reply_text=cleaned))
             return cleaned
         except Exception as err:
             audit.fail(str(err))

--- a/figwatch/skills.py
+++ b/figwatch/skills.py
@@ -194,7 +194,7 @@ def _get_introspection(skill_ref, skill_path, claude_path, model):
 
 # ── Prompt builder ────────────────────────────────────────────────────
 
-def _build_prompt(item, skill_content, refs_section, data, tree_data, frame_name, *, inline_files):
+def _build_prompt(item, skill_content, refs_section, data, tree_data, frame_name, *, inline_files, config=None):
     """Build the skill execution prompt.
 
     inline_files=True: node tree JSON is embedded directly (for API providers).
@@ -230,10 +230,22 @@ def _build_prompt(item, skill_content, refs_section, data, tree_data, frame_name
             data_desc.append(f'{key}: {json.dumps(data[key], indent=2)[:5000]}')
 
     data_section = '\n\n'.join(data_desc) if data_desc else 'No data available.'
-    extra_ctx = f'\nAdditional context from reviewer: "{item.extra}"' if item.extra else ''
+
+    # Support both Audit (trigger_match.extra) and WorkItem (extra)
+    extra = getattr(item, 'extra', None) or (
+        item.trigger_match.extra if hasattr(item, 'trigger_match') else ''
+    )
+    trigger_kw = getattr(item, 'trigger', None) or (
+        item.trigger_match.trigger.keyword if hasattr(item, 'trigger_match') else ''
+    )
+    reply_lang = getattr(item, 'reply_lang', None) or (
+        config.reply_lang if config else ''
+    )
+
+    extra_ctx = f'\nAdditional context from reviewer: "{extra}"' if extra else ''
     lang_instruction = (
         '\nIMPORTANT: Write your entire reply in Simplified Chinese.'
-        if item.reply_lang == 'cn' else ''
+        if reply_lang == 'cn' else ''
     )
     eval_instruction = (
         'Evaluate according to the skill using the data provided, then respond with ONLY a'
@@ -248,7 +260,7 @@ Use Mode 3 (Comment Reply) if the skill defines it.
 
 Now evaluate this screen:
 - Frame name: {frame_name}
-- Trigger: {item.trigger}{extra_ctx}
+- Trigger: {trigger_kw}{extra_ctx}
 
 Available data:
 {data_section}
@@ -266,9 +278,29 @@ CRITICAL RULES:
 
 # ── Skill execution ───────────────────────────────────────────────────
 
-def execute_skill(item):
-    """Execute any skill (builtin or custom) for a WorkItem. Returns the reply string."""
-    skill_ref = item.skill_path
+def execute_skill(item, *, config=None, design_repo=None):
+    """Execute any skill (builtin or custom). Returns the reply string.
+
+    Accepts either a WorkItem (legacy) or an Audit with config + design_repo.
+    """
+    # Extract fields from either Audit or WorkItem
+    if hasattr(item, 'trigger_match'):
+        # Audit aggregate
+        skill_ref = item.trigger_match.trigger.skill_ref
+        file_key = item.comment.file_key
+        node_id = item.comment.node_id
+        trigger_kw = item.trigger_match.trigger.keyword
+        model = config.model if config else 'gemini-flash'
+        claude_path = config.claude_path if config else 'api'
+    else:
+        # Legacy WorkItem
+        skill_ref = item.skill_path
+        file_key = item.file_key
+        node_id = item.node_id
+        trigger_kw = item.trigger
+        model = item.model
+        claude_path = item.claude_path
+
     skill_path = skill_ref
 
     if skill_path.startswith('builtin:'):
@@ -280,14 +312,17 @@ def execute_skill(item):
     if not os.path.exists(skill_path):
         raise FileNotFoundError(f'Skill file not found: {skill_path}')
 
-    intro = _get_introspection(skill_ref, skill_path, item.claude_path, item.model)
+    intro = _get_introspection(skill_ref, skill_path, claude_path, model)
     required_data = intro.get('required_data', ['screenshot', 'node_tree'])
     logger.debug(
         'fetching figma data',
         extra={'required': ','.join(required_data)},
     )
 
-    data, tree_data = fetch_figma_data(required_data, item.file_key, item.node_id, item.pat)
+    if design_repo is not None:
+        data, tree_data = design_repo.fetch(required_data, file_key, node_id)
+    else:
+        data, tree_data = fetch_figma_data(required_data, file_key, node_id, item.pat)
 
     with open(skill_path, encoding='utf-8') as f:
         skill_content = f.read()
@@ -309,19 +344,19 @@ def execute_skill(item):
             refs_section = '\n\nReference files:\n' + '\n\n'.join(ref_parts)
 
     frame_name = tree_data.get('name', 'Unknown frame') if tree_data else 'Unknown frame'
-    provider = make_provider(item.model, item.claude_path, skill_dir=skill_dir)
+    provider = make_provider(model, claude_path, skill_dir=skill_dir)
     logger.debug(
         'calling ai provider',
         extra={'provider': provider.name, 'frame': frame_name},
     )
     prompt = _build_prompt(
         item, skill_content, refs_section, data, tree_data, frame_name,
-        inline_files=provider.inline_files,
+        inline_files=provider.inline_files, config=config,
     )
 
     try:
         reply = provider.call(prompt, data.get('screenshot'))
-        header = f'\U0001f5e3\ufe0f {item.trigger} Audit \u2014 {frame_name}'
+        header = f'\U0001f5e3\ufe0f {trigger_kw} Audit \u2014 {frame_name}'
         return f'{header}\n\n{reply}\n\n\u2014 {provider.name}'
     finally:
         for key in ['screenshot', 'node_tree']:

--- a/figwatch/skills.py
+++ b/figwatch/skills.py
@@ -6,7 +6,6 @@ import os
 import re
 from pathlib import Path
 
-from figwatch.providers.figma import fetch_figma_data
 from figwatch.providers.ai import make_provider, GEMINI_MODELS, CLAUDE_API_MODELS
 from figwatch.providers.ai.gemini import GeminiProvider
 from figwatch.providers.ai.anthropic import AnthropicProvider
@@ -194,7 +193,7 @@ def _get_introspection(skill_ref, skill_path, claude_path, model):
 
 # ── Prompt builder ────────────────────────────────────────────────────
 
-def _build_prompt(item, skill_content, refs_section, data, tree_data, frame_name, *, inline_files, config=None):
+def _build_prompt(audit, skill_content, refs_section, data, tree_data, frame_name, *, inline_files, config=None):
     """Build the skill execution prompt.
 
     inline_files=True: node tree JSON is embedded directly (for API providers).
@@ -231,16 +230,9 @@ def _build_prompt(item, skill_content, refs_section, data, tree_data, frame_name
 
     data_section = '\n\n'.join(data_desc) if data_desc else 'No data available.'
 
-    # Support both Audit (trigger_match.extra) and WorkItem (extra)
-    extra = getattr(item, 'extra', None) or (
-        item.trigger_match.extra if hasattr(item, 'trigger_match') else ''
-    )
-    trigger_kw = getattr(item, 'trigger', None) or (
-        item.trigger_match.trigger.keyword if hasattr(item, 'trigger_match') else ''
-    )
-    reply_lang = getattr(item, 'reply_lang', None) or (
-        config.reply_lang if config else ''
-    )
+    extra = audit.trigger_match.extra
+    trigger_kw = audit.trigger_match.trigger.keyword
+    reply_lang = config.reply_lang if config else ''
 
     extra_ctx = f'\nAdditional context from reviewer: "{extra}"' if extra else ''
     lang_instruction = (
@@ -278,28 +270,14 @@ CRITICAL RULES:
 
 # ── Skill execution ───────────────────────────────────────────────────
 
-def execute_skill(item, *, config=None, design_repo=None):
-    """Execute any skill (builtin or custom). Returns the reply string.
-
-    Accepts either a WorkItem (legacy) or an Audit with config + design_repo.
-    """
-    # Extract fields from either Audit or WorkItem
-    if hasattr(item, 'trigger_match'):
-        # Audit aggregate
-        skill_ref = item.trigger_match.trigger.skill_ref
-        file_key = item.comment.file_key
-        node_id = item.comment.node_id
-        trigger_kw = item.trigger_match.trigger.keyword
-        model = config.model if config else 'gemini-flash'
-        claude_path = config.claude_path if config else 'api'
-    else:
-        # Legacy WorkItem
-        skill_ref = item.skill_path
-        file_key = item.file_key
-        node_id = item.node_id
-        trigger_kw = item.trigger
-        model = item.model
-        claude_path = item.claude_path
+def execute_skill(audit, *, config, design_repo):
+    """Execute any skill (builtin or custom) for an Audit. Returns the reply string."""
+    skill_ref = audit.trigger_match.trigger.skill_ref
+    file_key = audit.comment.file_key
+    node_id = audit.comment.node_id
+    trigger_kw = audit.trigger_match.trigger.keyword
+    model = config.model
+    claude_path = config.claude_path
 
     skill_path = skill_ref
 
@@ -319,10 +297,7 @@ def execute_skill(item, *, config=None, design_repo=None):
         extra={'required': ','.join(required_data)},
     )
 
-    if design_repo is not None:
-        data, tree_data = design_repo.fetch(required_data, file_key, node_id)
-    else:
-        data, tree_data = fetch_figma_data(required_data, file_key, node_id, item.pat)
+    data, tree_data = design_repo.fetch(required_data, file_key, node_id)
 
     with open(skill_path, encoding='utf-8') as f:
         skill_content = f.read()
@@ -350,7 +325,7 @@ def execute_skill(item, *, config=None, design_repo=None):
         extra={'provider': provider.name, 'frame': frame_name},
     )
     prompt = _build_prompt(
-        item, skill_content, refs_section, data, tree_data, frame_name,
+        audit, skill_content, refs_section, data, tree_data, frame_name,
         inline_files=provider.inline_files, config=config,
     )
 

--- a/figwatch/trigger_config.py
+++ b/figwatch/trigger_config.py
@@ -1,0 +1,80 @@
+"""Trigger configuration loading — application-layer I/O."""
+
+import json
+import os
+from pathlib import Path
+
+
+DEFAULT_TRIGGERS = [
+    {"trigger": "@tone", "skill": "builtin:tone"},
+    {"trigger": "@ux", "skill": "builtin:ux"},
+]
+
+
+def _discover_custom_triggers(skills_dir=None):
+    """Scan custom-skills directory for .md files and return trigger entries.
+
+    Supports flat files (a11y.md → @a11y) and subdirectories (a11y/skill.md → @a11y).
+
+    Args:
+        skills_dir: Path to the custom-skills directory. Defaults to
+                    ``os.getcwd() / 'custom-skills'`` when *None*.
+    """
+    custom_dir = Path(skills_dir) if skills_dir else Path(os.getcwd()) / 'custom-skills'
+    if not custom_dir.is_dir():
+        return []
+
+    triggers = []
+    seen = set()
+
+    for path in sorted(custom_dir.glob('*.md')):
+        name = path.stem
+        if name not in seen:
+            seen.add(name)
+            triggers.append({'trigger': f'@{name}', 'skill': str(path.resolve())})
+
+    for skill_dir in sorted(p for p in custom_dir.iterdir() if p.is_dir()):
+        name = skill_dir.name
+        if name in seen:
+            continue
+        for fname in ['skill.md', 'SKILL.md']:
+            skill_path = skill_dir / fname
+            if skill_path.exists():
+                seen.add(name)
+                triggers.append({'trigger': f'@{name}', 'skill': str(skill_path.resolve())})
+                break
+
+    return triggers
+
+
+def load_trigger_config(skills_dir=None):
+    """Load trigger config from config file or built-in defaults, plus any custom skills.
+
+    Priority:
+      1. ~/.figwatch/config.json  (written by the macOS app)
+      2. Built-in defaults        (@tone, @ux)
+
+    In both cases, any .md files found in the custom-skills directory are appended
+    automatically.
+
+    Args:
+        skills_dir: Path to the custom-skills directory. Passed through to
+                    :func:`_discover_custom_triggers`.
+    """
+    custom = _discover_custom_triggers(skills_dir)
+
+    try:
+        config_path = os.path.join(os.path.expanduser('~'), '.figwatch', 'config.json')
+        with open(config_path) as f:
+            config = json.load(f)
+        triggers = config.get('triggers')
+        if triggers and isinstance(triggers, list):
+            existing = {t.get('trigger') for t in triggers}
+            for t in custom:
+                if t['trigger'] not in existing:
+                    triggers.append(t)
+            return triggers
+    except Exception:
+        pass
+
+    return list(DEFAULT_TRIGGERS) + custom

--- a/figwatch/watcher.py
+++ b/figwatch/watcher.py
@@ -226,10 +226,18 @@ class FigmaWatcher:
 
     def _execute_audit(self, audit):
         """Execute audit via AuditService and notify event listener."""
+        trigger_name = audit.trigger_match.trigger.keyword.lstrip('@')
+        ack_id = self.audit_service.post_ack(
+            audit,
+            f'\u23f3 {trigger_name} audit received \u2014 working on it\u2026',
+        )
+
         try:
             response = self.audit_service.execute(audit)
+            self.audit_service.delete_ack(audit, ack_id)
             self.audit_service.post_reply(audit, response)
         except Exception as err:
+            self.audit_service.delete_ack(audit, ack_id)
             try:
                 self.audit_service.post_reply(
                     audit,

--- a/figwatch/watcher.py
+++ b/figwatch/watcher.py
@@ -6,7 +6,8 @@ import os
 import threading
 from collections import OrderedDict
 
-from figwatch.domain import WorkItem, load_trigger_config, match_trigger
+from figwatch.domain import WorkItem, match_trigger
+from figwatch.trigger_config import load_trigger_config
 from figwatch.processor import process_work_item
 from figwatch.providers.figma import figma_get
 
@@ -143,10 +144,10 @@ def detect_triggers(file_key, pat, processed_ids, trigger_config, *, log, on_sta
             comment_id=comment['id'],
             reply_to_id=reply_to_id,
             node_id=node_id,
-            trigger=match['trigger'],
-            skill_path=match['skill'],
+            trigger=match.trigger.keyword,
+            skill_path=match.trigger.skill_ref,
             user_handle=user_handle,
-            extra=match['extra'],
+            extra=match.extra,
             locale=None,
             model=None,
             reply_lang=None,
@@ -155,7 +156,7 @@ def detect_triggers(file_key, pat, processed_ids, trigger_config, *, log, on_sta
             on_status=on_status,
         )
         items.append(item)
-        log(f'\U0001f4ac {match["trigger"]} comment by {user_handle} on node {node_id}')
+        log(f'\U0001f4ac {match.trigger.keyword} comment by {user_handle} on node {node_id}')
 
     if len(processed_ids) > initial_count:
         save_processed(processed_ids)

--- a/figwatch/watcher.py
+++ b/figwatch/watcher.py
@@ -1,4 +1,4 @@
-"""FigWatch comment watcher — polls Figma for trigger comments and dispatches work items."""
+"""FigWatch comment watcher — polls Figma for trigger comments and dispatches audits."""
 
 import json
 import logging
@@ -6,10 +6,10 @@ import os
 import threading
 from collections import OrderedDict
 
-from figwatch.domain import WorkItem, match_trigger
-from figwatch.trigger_config import load_trigger_config
-from figwatch.processor import process_work_item
+from figwatch.domain import Audit, AuditStatus, Comment, match_trigger
+from figwatch.log_context import new_audit_id
 from figwatch.providers.figma import figma_get
+from figwatch.trigger_config import load_trigger_config
 
 logger = logging.getLogger(__name__)
 
@@ -86,8 +86,8 @@ def save_processed(ids):
 
 # ── Trigger detection (fast path — 1 API call) ────────────────────────
 
-def detect_triggers(file_key, pat, processed_ids, trigger_config, *, log, on_status=None):
-    """Fetch comments, find trigger matches, return list[WorkItem].
+def detect_triggers(file_key, pat, processed_ids, trigger_config, *, log):
+    """Fetch comments, find trigger matches, return list[Audit].
 
     Fast path: single API call, <1s. Does NOT call any AI provider.
     """
@@ -114,23 +114,24 @@ def detect_triggers(file_key, pat, processed_ids, trigger_config, *, log, on_sta
                 candidates.append(c)
 
     initial_count = len(processed_ids)
-    items = []
+    audits = []
     for comment in candidates:
         if comment['id'] in processed_ids or comment['id'] in replied_to:
             continue
         if comment.get('parent_id') and comment['parent_id'] in replied_to:
             continue
 
-        match = match_trigger(comment.get('message', ''), trigger_config)
-        if not match:
+        trigger_match = match_trigger(comment.get('message', ''), trigger_config)
+        if not trigger_match:
             continue
 
         node_id = (comment.get('client_meta') or {}).get('node_id')
         reply_to_id = comment['id']
+        parent_id = None
         if comment.get('parent_id'):
             parent = comment_map.get(comment['parent_id'])
             node_id = node_id or ((parent.get('client_meta') or {}).get('node_id') if parent else None)
-            reply_to_id = comment['parent_id']
+            parent_id = comment['parent_id']
 
         if not node_id:
             processed_ids.add(comment['id'])
@@ -139,52 +140,43 @@ def detect_triggers(file_key, pat, processed_ids, trigger_config, *, log, on_sta
         processed_ids.add(comment['id'])
         user_handle = comment.get('user', {}).get('handle', 'unknown')
 
-        item = WorkItem(
-            file_key=file_key,
-            comment_id=comment['id'],
-            reply_to_id=reply_to_id,
-            node_id=node_id,
-            trigger=match.trigger.keyword,
-            skill_path=match.trigger.skill_ref,
-            user_handle=user_handle,
-            extra=match.extra,
-            locale=None,
-            model=None,
-            reply_lang=None,
-            pat=pat,
-            claude_path=None,
-            on_status=on_status,
+        audit = Audit(
+            audit_id=new_audit_id(),
+            comment=Comment(
+                comment_id=comment['id'],
+                message=comment.get('message', ''),
+                parent_id=parent_id,
+                node_id=node_id,
+                user_handle=user_handle,
+                file_key=file_key,
+            ),
+            trigger_match=trigger_match,
         )
-        items.append(item)
-        log(f'\U0001f4ac {match.trigger.keyword} comment by {user_handle} on node {node_id}')
+        audits.append(audit)
+        log(f'\U0001f4ac {trigger_match.trigger.keyword} comment by {user_handle} on node {node_id}')
 
     if len(processed_ids) > initial_count:
         save_processed(processed_ids)
-    return items
+    return audits
 
 
 # ── Watcher class ─────────────────────────────────────────────────────
 
 class FigmaWatcher:
-    def __init__(self, file_key, pat, *, locale='uk', model='sonnet', reply_lang='en',
-                 interval=30, claude_path='claude', log=print,
-                 trigger_config=None, dispatch=None, on_poll=None, on_status=None,
-                 initial_delay=0,
-                 on_reply=None):  # on_reply deprecated — use on_status
+    def __init__(self, file_key, pat, *, audit_service,
+                 interval=30, log=print,
+                 trigger_config=None, dispatch=None, on_poll=None,
+                 initial_delay=0, event_listener=None):
         self.file_key = file_key
         self.pat = pat
-        self.locale = locale
-        self.model = model
-        self.reply_lang = reply_lang
+        self.audit_service = audit_service
         self.interval = interval
-        self.claude_path = claude_path
         self.log = log
         self.trigger_config = trigger_config or load_trigger_config()
         self.dispatch = dispatch
         self.on_poll = on_poll
-        self.on_status = on_status
         self.initial_delay = initial_delay
-        self._on_reply = on_reply
+        self._event_listener = event_listener
         self._stop_event = threading.Event()
         self._thread = None
         self._processed = load_processed()
@@ -216,24 +208,15 @@ class FigmaWatcher:
 
         while not self._stop_event.is_set():
             try:
-                items = detect_triggers(
+                audits = detect_triggers(
                     self.file_key, self.pat, self._processed,
-                    self.trigger_config, log=self.log, on_status=self.on_status,
+                    self.trigger_config, log=self.log,
                 )
-                for item in items:
-                    item = item._replace(
-                        locale=self.locale,
-                        model=self.model,
-                        reply_lang=self.reply_lang,
-                        claude_path=self.claude_path,
-                        on_status=self.on_status,
-                    )
+                for audit in audits:
                     if self.dispatch:
-                        self.dispatch(item)
+                        self.dispatch(audit)
                     else:
-                        process_work_item(item, trigger_config=self.trigger_config)
-                        if self._on_reply:
-                            self._on_reply(item.trigger, item.user_handle, item.node_id)
+                        self._execute_audit(audit)
 
                 if self.on_poll:
                     self.on_poll()
@@ -241,11 +224,32 @@ class FigmaWatcher:
                 self.log(f'\u26a0\ufe0f Poll error: {err}')
             self._stop_event.wait(timeout=self.interval)
 
+    def _execute_audit(self, audit):
+        """Execute audit via AuditService and notify event listener."""
+        try:
+            response = self.audit_service.execute(audit)
+            self.audit_service.post_reply(audit, response)
+        except Exception as err:
+            try:
+                self.audit_service.post_reply(
+                    audit,
+                    f'Audit failed: {err}\n\n{_EM_DASH} FigWatch',
+                )
+            except Exception:
+                logger.exception('error reply post also failed')
+
+        if self._event_listener:
+            for event in audit.collect_events():
+                self._event_listener(event, audit)
+
 
 # ── CLI entry point ───────────────────────────────────────────────────
 
 if __name__ == '__main__':
     import sys
+
+    from figwatch.providers.figma import FigmaCommentRepository, FigmaDesignDataRepository
+    from figwatch.services import AuditConfig, AuditService
 
     args = sys.argv[1:]
     if not args or args[0] != 'watch' or len(args) < 2:
@@ -277,7 +281,13 @@ if __name__ == '__main__':
         print('\u274c No Figma PAT found in ~/.figwatch/config.json')
         sys.exit(1)
 
-    w = FigmaWatcher(file_key, pat, locale=locale, interval=interval)
+    svc = AuditService(
+        comment_repo=FigmaCommentRepository(pat),
+        design_repo=FigmaDesignDataRepository(pat),
+        config=AuditConfig(model='sonnet', claude_path='api', reply_lang='en', locale=locale),
+        trigger_config=load_trigger_config(),
+    )
+    w = FigmaWatcher(file_key, pat, audit_service=svc, interval=interval)
     w.start()
 
     try:

--- a/macos/FigWatch.py
+++ b/macos/FigWatch.py
@@ -24,7 +24,13 @@ from Foundation import *
 from PyObjCTools import AppHelper
 
 import figwatch.handlers as handlers
-from figwatch.domain import STATUS_LIVE, STATUS_DETECTED, STATUS_PROCESSING, STATUS_REPLIED, STATUS_ERROR
+from figwatch.domain import AuditStarted, AuditCompleted, AuditFailed, AuditStatus, STATUS_LIVE
+
+# String status values for UI state tracking
+STATUS_DETECTED = AuditStatus.DETECTED.value
+STATUS_PROCESSING = AuditStatus.PROCESSING.value
+STATUS_REPLIED = AuditStatus.REPLIED.value
+STATUS_ERROR = AuditStatus.ERROR.value
 
 # ── Config ──────────────────────────────────────────────────────────
 
@@ -889,15 +895,35 @@ class FigWatch(NSObject):
             self._state["workers"].append(t)
 
     def _worker_loop(self, q):
-        from figwatch.processor import process_work_item
         while True:
-            item = q.get()
-            if item is None:
+            audit = q.get()
+            if audit is None:
                 break
             try:
-                process_work_item(item)
+                svc = self._state.get("audit_service")
+                if svc:
+                    response = svc.execute(audit)
+                    svc.post_reply(audit, response)
             except Exception:
                 pass
+
+    def _build_audit_service(self):
+        """Construct AuditService for macOS polling path."""
+        from figwatch.providers.figma import FigmaCommentRepository, FigmaDesignDataRepository
+        from figwatch.services import AuditConfig, AuditService
+
+        pat = self._state["pat"]
+        return AuditService(
+            comment_repo=FigmaCommentRepository(pat),
+            design_repo=FigmaDesignDataRepository(pat),
+            config=AuditConfig(
+                model=self._state.get("model", "sonnet"),
+                claude_path=_resolve_claude_path(),
+                reply_lang=self._state.get("reply_lang", "en"),
+                locale=self._state.get("locale", "uk"),
+            ),
+            trigger_config=self._state["trigger_config"],
+        )
 
     def _start_watcher(self, f, initial_delay=0):
         from figwatch.watcher import FigmaWatcher
@@ -911,32 +937,37 @@ class FigWatch(NSObject):
             "last_poll": None, "error": None,
         }
 
-        def on_status(event, item, **kwargs):
+        # Lazily construct audit service
+        if "audit_service" not in self._state:
+            self._state["audit_service"] = self._build_audit_service()
+
+        def event_listener(event, audit):
             if key not in self._state["file_statuses"]:
                 return
             fs = self._state["file_statuses"][key]
-            if event == STATUS_PROCESSING:
+            if isinstance(event, AuditStarted):
                 fs["status"] = STATUS_PROCESSING
-                fs["trigger"] = item.trigger
-                fs["user"] = item.user_handle
-            elif event == STATUS_REPLIED:
+                fs["trigger"] = audit.trigger_match.trigger.keyword
+                fs["user"] = audit.comment.user_handle
+            elif isinstance(event, AuditCompleted):
                 fs["status"] = STATUS_REPLIED
                 def _revert(k=key):
                     if k in self._state.get("file_statuses", {}):
                         self._state["file_statuses"][k]["status"] = STATUS_LIVE
                         self._schedule_refresh()
                 threading.Timer(4.0, _revert).start()
-            elif event == STATUS_ERROR:
+            elif isinstance(event, AuditFailed):
                 fs["status"] = STATUS_ERROR
-                fs["error"] = kwargs.get("error", "Unknown error")
+                fs["error"] = event.error
             self._schedule_refresh()
             self._update_icon_state()
 
-        def dispatch(item):
-            if item.trigger == "@tone":
-                self._state["work_queue_tone"].put(item)
+        def dispatch(audit):
+            trigger_kw = audit.trigger_match.trigger.keyword
+            if trigger_kw == "@tone":
+                self._state["work_queue_tone"].put(audit)
             else:
-                self._state["work_queue_ux"].put(item)
+                self._state["work_queue_ux"].put(audit)
 
         def on_poll():
             if key in self._state["file_statuses"]:
@@ -944,15 +975,12 @@ class FigWatch(NSObject):
 
         w = FigmaWatcher(
             key, self._state["pat"],
-            locale=self._state.get("locale", "uk"),
-            model=self._state.get("model", "sonnet"),
-            reply_lang=self._state.get("reply_lang", "en"),
-            claude_path=_resolve_claude_path(),
+            audit_service=self._state["audit_service"],
             log=self._write_log,
             trigger_config=self._state["trigger_config"],
             dispatch=dispatch,
             on_poll=on_poll,
-            on_status=on_status,
+            event_listener=event_listener,
             initial_delay=initial_delay,
         )
         w.start()

--- a/macos/FigWatch.py
+++ b/macos/FigWatch.py
@@ -804,7 +804,7 @@ class FigWatch(NSObject):
         """Background init: validate PAT, load config, start watchers."""
         self._state["user"] = _validate_token(self._state["pat"])
 
-        from figwatch.domain import load_trigger_config
+        from figwatch.trigger_config import load_trigger_config
         self._state["trigger_config"] = load_trigger_config()
 
         if not os.path.exists(WATCHED_PATH) and os.path.exists(RECENTS_PATH):

--- a/server.py
+++ b/server.py
@@ -59,7 +59,8 @@ if _repo_root not in sys.path:
     sys.path.insert(0, _repo_root)
 
 from figwatch.ack_updater import AckUpdater
-from figwatch.domain import WorkItem, load_trigger_config, match_trigger
+from figwatch.domain import WorkItem, match_trigger
+from figwatch.trigger_config import load_trigger_config
 from figwatch.log_context import (
     new_audit_id, set_audit_context, reset_audit_context, clear_audit_context,
 )
@@ -151,10 +152,10 @@ def _build_work_item(payload, comment_id, pat, allowed_file_keys, locale, model,
         comment_id=comment_id,
         reply_to_id=reply_to_id,
         node_id=node_id,
-        trigger=match['trigger'],
-        skill_path=match['skill'],
+        trigger=match.trigger.keyword,
+        skill_path=match.trigger.skill_ref,
         user_handle=(comment.get('user') or payload.get('triggered_by') or {}).get('handle', 'unknown'),
-        extra=match['extra'],
+        extra=match.extra,
         locale=locale,
         model=model,
         reply_lang='en',

--- a/server.py
+++ b/server.py
@@ -59,7 +59,10 @@ if _repo_root not in sys.path:
     sys.path.insert(0, _repo_root)
 
 from figwatch.ack_updater import AckUpdater
-from figwatch.domain import WorkItem, match_trigger
+from figwatch.domain import (
+    Audit, AuditStatus, Comment, Trigger, TriggerMatch,
+    WorkItem, match_trigger,
+)
 from figwatch.trigger_config import load_trigger_config
 from figwatch.log_context import (
     new_audit_id, set_audit_context, reset_audit_context, clear_audit_context,
@@ -73,8 +76,11 @@ from figwatch.processor import (
     clean_reply, delete_ack, post_ack, post_reply, update_ack,
 )
 from figwatch.providers.ai import CLAUDE_API_MODELS, GEMINI_MODELS
-from figwatch.providers.figma import figma_get_retry
+from figwatch.providers.figma import (
+    FigmaCommentRepository, FigmaDesignDataRepository, figma_get_retry,
+)
 from figwatch.queue_stats import InstrumentedQueue, QueuedItem
+from figwatch.services import AuditConfig, AuditService
 from figwatch.skills import execute_skill
 from figwatch.watcher import load_processed, save_processed
 from figwatch.webhook_monitor import WebhookMonitor
@@ -168,8 +174,8 @@ def _build_work_item(payload, comment_id, pat, allowed_file_keys, locale, model,
 
 # ── Worker loop ────────────────────────────────────────────────────────
 
-def _run_audit(item, ack_id, trigger_config):
-    """Execute the skill and post the reply. Raises on failure."""
+def _run_audit_legacy(item, ack_id, trigger_config):
+    """Execute the skill and post the reply (legacy path). Raises on failure."""
     logger.info('running skill', extra={'skill': item.skill_path})
     response = execute_skill(item)
     logger.info('skill returned', extra={'chars': len(response)})
@@ -180,8 +186,20 @@ def _run_audit(item, ack_id, trigger_config):
     logger.info('reply posted', extra={'reply_to': item.reply_to_id})
 
 
+def _run_audit_service(audit, ack_id, audit_service):
+    """Execute via AuditService. Raises on failure."""
+    trigger_kw = audit.trigger_match.trigger.keyword
+    logger.info('running skill', extra={'skill': audit.trigger_match.trigger.skill_ref})
+    response = audit_service.execute(audit)
+    logger.info('skill returned', extra={'chars': len(response)})
+
+    audit_service.delete_ack(audit, ack_id)
+    audit_service.post_reply(audit, response)
+    logger.info('reply posted', extra={'reply_to': audit.reply_to_id})
+
+
 def _worker_loop(work_queue: InstrumentedQueue, stop_event, trigger_config,
-                 max_attempts, ack_updater: AckUpdater):
+                 max_attempts, ack_updater: AckUpdater, audit_service: AuditService = None):
     while not stop_event.is_set():
         queued = work_queue.get(timeout=1)
         if queued is None:
@@ -193,15 +211,28 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event, trigger_config,
         # BEFORE reading ack_id so we can't race with an in-flight update.
         ack_updater.cancel(queued.audit_id)
 
+        audit = queued.audit
         item = queued.item
+        use_service = audit is not None and audit_service is not None
+
+        # Extract trigger/node/file from whichever is available
+        if use_service:
+            trigger_kw = audit.trigger_match.trigger.keyword
+            node_id = audit.comment.node_id
+            file_key = audit.comment.file_key
+        else:
+            trigger_kw = item.trigger
+            node_id = item.node_id
+            file_key = item.file_key
+
         ack_id = queued.ack_id
         run_started_at = time.monotonic()
 
         token = set_audit_context(
             audit=queued.audit_id,
-            trigger=item.trigger,
-            node=item.node_id,
-            file=item.file_key,
+            trigger=trigger_kw,
+            node=node_id,
+            file=file_key,
             attempt=queued.attempt,
         )
         try:
@@ -212,10 +243,16 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event, trigger_config,
                 extra={'depth': stats.depth, 'waited': f'{queued.waited_seconds:.2f}s'},
             )
 
-            ack_id = update_ack(
-                item, ack_id,
-                f'\u23f3 Running {item.trigger.lstrip("@")} audit\u2026',
-            )
+            if use_service:
+                ack_id = audit_service.update_ack(
+                    audit, ack_id,
+                    f'\u23f3 Running {trigger_kw.lstrip("@")} audit\u2026',
+                )
+            else:
+                ack_id = update_ack(
+                    item, ack_id,
+                    f'\u23f3 Running {trigger_kw.lstrip("@")} audit\u2026',
+                )
 
             last_err = None
             success = False
@@ -224,7 +261,10 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event, trigger_config,
                 if attempt > 0:
                     set_audit_context(attempt=attempt + 1)
                 try:
-                    _run_audit(item, ack_id, trigger_config)
+                    if use_service:
+                        _run_audit_service(audit, ack_id, audit_service)
+                    else:
+                        _run_audit_legacy(item, ack_id, trigger_config)
                     ack_id = None
                     success = True
                     break
@@ -238,14 +278,24 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event, trigger_config,
                     if attempt >= max_attempts - 1:
                         break
                     backoff = _BACKOFFS[min(attempt, len(_BACKOFFS) - 1)]
-                    ack_id = update_ack(
-                        item, ack_id,
-                        (
-                            f'\u23f3 {item.trigger.lstrip("@")} audit hit a snag '
-                            f'({err}). Retrying in {backoff}s '
-                            f'(attempt {attempt + 2}/{max_attempts})\u2026'
-                        ),
-                    )
+                    if use_service:
+                        ack_id = audit_service.update_ack(
+                            audit, ack_id,
+                            (
+                                f'\u23f3 {trigger_kw.lstrip("@")} audit hit a snag '
+                                f'({err}). Retrying in {backoff}s '
+                                f'(attempt {attempt + 2}/{max_attempts})\u2026'
+                            ),
+                        )
+                    else:
+                        ack_id = update_ack(
+                            item, ack_id,
+                            (
+                                f'\u23f3 {trigger_kw.lstrip("@")} audit hit a snag '
+                                f'({err}). Retrying in {backoff}s '
+                                f'(attempt {attempt + 2}/{max_attempts})\u2026'
+                            ),
+                        )
                     if stop_event.wait(timeout=backoff):
                         logger.info('shutdown during backoff — aborting retry')
                         break
@@ -254,7 +304,10 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event, trigger_config,
             total_seconds = time.monotonic() - queued.enqueued_at
 
             if success:
-                record_audit_completed(total_seconds, 'success')
+                if use_service:
+                    audit_service.dispatch_events(audit, total_seconds)
+                else:
+                    record_audit_completed(total_seconds, 'success')
                 logger.info(
                     '\u2705 audit.completed',
                     extra={
@@ -265,18 +318,32 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event, trigger_config,
                     },
                 )
             else:
-                delete_ack(item, ack_id)
-                try:
-                    post_reply(
-                        item,
-                        (
-                            f'Audit failed after {max_attempts} attempts.\n'
-                            f'Last error: {last_err}\n\n{_EM_DASH} FigWatch'
-                        ),
-                    )
-                except Exception:
-                    logger.exception('error reply post failed')
-                record_audit_completed(total_seconds, 'failed')
+                if use_service:
+                    audit_service.delete_ack(audit, ack_id)
+                    try:
+                        audit_service.post_reply(
+                            audit,
+                            (
+                                f'Audit failed after {max_attempts} attempts.\n'
+                                f'Last error: {last_err}\n\n{_EM_DASH} FigWatch'
+                            ),
+                        )
+                    except Exception:
+                        logger.exception('error reply post failed')
+                    audit_service.dispatch_events(audit, total_seconds)
+                else:
+                    delete_ack(item, ack_id)
+                    try:
+                        post_reply(
+                            item,
+                            (
+                                f'Audit failed after {max_attempts} attempts.\n'
+                                f'Last error: {last_err}\n\n{_EM_DASH} FigWatch'
+                            ),
+                        )
+                    except Exception:
+                        logger.exception('error reply post failed')
+                    record_audit_completed(total_seconds, 'failed')
                 logger.error(
                     '\u274c audit.failed',
                     extra={
@@ -298,7 +365,8 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event, trigger_config,
 
 def _make_handler(pat, passcode, allowed_file_keys, locale, model, claude_path,
                   trigger_config, processed_ids, processed_lock, work_queue,
-                  ack_updater: AckUpdater, received_events, received_lock):
+                  ack_updater: AckUpdater, received_events, received_lock,
+                  audit_service: AuditService = None):
     class WebhookHandler(BaseHTTPRequestHandler):
         def do_GET(self):
             if self.path == '/health':
@@ -375,6 +443,24 @@ def _make_handler(pat, passcode, allowed_file_keys, locale, model, claude_path,
             save_processed(processed_ids)
 
             audit_id = new_audit_id()
+
+            # Build Audit aggregate alongside legacy WorkItem
+            comment_obj = payload.get('comment') or {}
+            message = comment_obj.get('message') or comment_obj.get('text', '')
+            trigger_match = match_trigger(message, trigger_config)
+            audit_obj = Audit(
+                audit_id=audit_id,
+                comment=Comment(
+                    comment_id=str(comment_id),
+                    message=message,
+                    parent_id=item.reply_to_id if item.reply_to_id != str(comment_id) else None,
+                    node_id=item.node_id,
+                    user_handle=item.user_handle,
+                    file_key=item.file_key,
+                ),
+                trigger_match=trigger_match,
+            )
+
             # Temporarily set context so the ack post + enqueue log lines
             # carry the new audit_id. Cleared on next request.
             set_audit_context(
@@ -400,12 +486,17 @@ def _make_handler(pat, passcode, allowed_file_keys, locale, model, claude_path,
                     f'\u23f3 {item.trigger.lstrip("@")} audit queued '
                     f'({ahead} ahead of you)\u2026'
                 )
-            ack_id = post_ack(item, queue_msg)
+
+            if audit_service:
+                ack_id = audit_service.post_ack(audit_obj, queue_msg)
+            else:
+                ack_id = post_ack(item, queue_msg)
 
             queued = QueuedItem(
                 item=item,
                 ack_id=ack_id,
                 audit_id=audit_id,
+                audit=audit_obj,
             )
             work_queue.put(queued)
             record_queue_change(1)
@@ -541,6 +632,15 @@ def main():
     trigger_config = load_trigger_config(skills_dir)
     triggers_str = ', '.join(t.get('trigger', '') for t in trigger_config)
 
+    # Construct repositories and application service
+    comment_repo = FigmaCommentRepository(pat)
+    design_repo = FigmaDesignDataRepository(pat)
+    audit_config = AuditConfig(
+        model=model, claude_path=claude_path,
+        reply_lang='en', locale=locale,
+    )
+    audit_service = AuditService(comment_repo, design_repo, audit_config, trigger_config)
+
     processed_ids = load_processed()
     processed_lock = threading.Lock()
     received_events = {}   # {comment_id: receive_unix_timestamp} for webhook monitoring
@@ -565,7 +665,8 @@ def main():
     worker_threads = [
         threading.Thread(
             target=_worker_loop,
-            args=(work_queue, stop_event, trigger_config, max_attempts, ack_updater),
+            args=(work_queue, stop_event, trigger_config, max_attempts,
+                  ack_updater, audit_service),
             name=f'figwatch-worker-{i}',
             daemon=True,
         )
@@ -579,6 +680,7 @@ def main():
         locale, model, claude_path,
         trigger_config, processed_ids, processed_lock, work_queue,
         ack_updater, received_events, received_lock,
+        audit_service,
     )
     server = HTTPServer(('', port), handler)
 

--- a/server.py
+++ b/server.py
@@ -59,21 +59,14 @@ if _repo_root not in sys.path:
     sys.path.insert(0, _repo_root)
 
 from figwatch.ack_updater import AckUpdater
-from figwatch.domain import (
-    Audit, AuditStatus, Comment, Trigger, TriggerMatch,
-    WorkItem, match_trigger,
-)
+from figwatch.domain import Audit, Comment, match_trigger
 from figwatch.trigger_config import load_trigger_config
 from figwatch.log_context import (
     new_audit_id, set_audit_context, reset_audit_context, clear_audit_context,
 )
 from figwatch.logging_config import configure_logging
 from figwatch.metrics import (
-    init_metrics, record_audit_completed, record_queue_change,
-    record_webhook_received,
-)
-from figwatch.processor import (
-    clean_reply, delete_ack, post_ack, post_reply, update_ack,
+    init_metrics, record_queue_change, record_webhook_received,
 )
 from figwatch.providers.ai import CLAUDE_API_MODELS, GEMINI_MODELS
 from figwatch.providers.figma import (
@@ -81,7 +74,6 @@ from figwatch.providers.figma import (
 )
 from figwatch.queue_stats import InstrumentedQueue, QueuedItem
 from figwatch.services import AuditConfig, AuditService
-from figwatch.skills import execute_skill
 from figwatch.watcher import load_processed, save_processed
 from figwatch.webhook_monitor import WebhookMonitor
 
@@ -133,8 +125,8 @@ def _resolve_node_id(comment, file_key, pat, comment_id=None):
     return None
 
 
-def _build_work_item(payload, comment_id, pat, allowed_file_keys, locale, model, claude_path, trigger_config):
-    """Parse a FILE_COMMENT payload into a WorkItem, or return (None, reason)."""
+def _build_audit(payload, comment_id, pat, allowed_file_keys, trigger_config, audit_id):
+    """Parse a FILE_COMMENT payload into an Audit, or return (None, reason)."""
     file_key = payload.get('file_key')
     if allowed_file_keys and file_key not in allowed_file_keys:
         return None, 'file not in allowlist'
@@ -142,53 +134,37 @@ def _build_work_item(payload, comment_id, pat, allowed_file_keys, locale, model,
     comment = payload.get('comment') or {}
     message = comment.get('message') or comment.get('text', '')
 
-    match = match_trigger(message, trigger_config)
-    if not match:
+    trigger_match = match_trigger(message, trigger_config)
+    if not trigger_match:
         return None, 'no trigger'
 
     parent_id = comment.get('parent_id') or ''
-    reply_to_id = parent_id or comment_id
 
     node_id = _resolve_node_id(comment, file_key, pat, comment_id=comment_id)
     if not node_id:
         return None, 'no node_id'
 
-    item = WorkItem(
-        file_key=file_key,
-        comment_id=comment_id,
-        reply_to_id=reply_to_id,
-        node_id=node_id,
-        trigger=match.trigger.keyword,
-        skill_path=match.trigger.skill_ref,
-        user_handle=(comment.get('user') or payload.get('triggered_by') or {}).get('handle', 'unknown'),
-        extra=match.extra,
-        locale=locale,
-        model=model,
-        reply_lang='en',
-        pat=pat,
-        claude_path=claude_path,
-        on_status=None,
+    user_handle = (comment.get('user') or payload.get('triggered_by') or {}).get('handle', 'unknown')
+
+    audit = Audit(
+        audit_id=audit_id,
+        comment=Comment(
+            comment_id=str(comment_id),
+            message=message,
+            parent_id=parent_id or None,
+            node_id=node_id,
+            user_handle=user_handle,
+            file_key=file_key,
+        ),
+        trigger_match=trigger_match,
     )
-    return item, None
+    return audit, None
 
 
 # ── Worker loop ────────────────────────────────────────────────────────
 
-def _run_audit_legacy(item, ack_id, trigger_config):
-    """Execute the skill and post the reply (legacy path). Raises on failure."""
-    logger.info('running skill', extra={'skill': item.skill_path})
-    response = execute_skill(item)
-    logger.info('skill returned', extra={'chars': len(response)})
-
-    delete_ack(item, ack_id)
-    response = clean_reply(response, trigger_config)
-    post_reply(item, response)
-    logger.info('reply posted', extra={'reply_to': item.reply_to_id})
-
-
-def _run_audit_service(audit, ack_id, audit_service):
+def _run_audit(audit, ack_id, audit_service):
     """Execute via AuditService. Raises on failure."""
-    trigger_kw = audit.trigger_match.trigger.keyword
     logger.info('running skill', extra={'skill': audit.trigger_match.trigger.skill_ref})
     response = audit_service.execute(audit)
     logger.info('skill returned', extra={'chars': len(response)})
@@ -198,8 +174,8 @@ def _run_audit_service(audit, ack_id, audit_service):
     logger.info('reply posted', extra={'reply_to': audit.reply_to_id})
 
 
-def _worker_loop(work_queue: InstrumentedQueue, stop_event, trigger_config,
-                 max_attempts, ack_updater: AckUpdater, audit_service: AuditService = None):
+def _worker_loop(work_queue: InstrumentedQueue, stop_event,
+                 max_attempts, ack_updater: AckUpdater, audit_service: AuditService):
     while not stop_event.is_set():
         queued = work_queue.get(timeout=1)
         if queued is None:
@@ -212,27 +188,15 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event, trigger_config,
         ack_updater.cancel(queued.audit_id)
 
         audit = queued.audit
-        item = queued.item
-        use_service = audit is not None and audit_service is not None
-
-        # Extract trigger/node/file from whichever is available
-        if use_service:
-            trigger_kw = audit.trigger_match.trigger.keyword
-            node_id = audit.comment.node_id
-            file_key = audit.comment.file_key
-        else:
-            trigger_kw = item.trigger
-            node_id = item.node_id
-            file_key = item.file_key
-
+        trigger_kw = audit.trigger_match.trigger.keyword
         ack_id = queued.ack_id
         run_started_at = time.monotonic()
 
         token = set_audit_context(
             audit=queued.audit_id,
             trigger=trigger_kw,
-            node=node_id,
-            file=file_key,
+            node=audit.comment.node_id,
+            file=audit.comment.file_key,
             attempt=queued.attempt,
         )
         try:
@@ -243,16 +207,10 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event, trigger_config,
                 extra={'depth': stats.depth, 'waited': f'{queued.waited_seconds:.2f}s'},
             )
 
-            if use_service:
-                ack_id = audit_service.update_ack(
-                    audit, ack_id,
-                    f'\u23f3 Running {trigger_kw.lstrip("@")} audit\u2026',
-                )
-            else:
-                ack_id = update_ack(
-                    item, ack_id,
-                    f'\u23f3 Running {trigger_kw.lstrip("@")} audit\u2026',
-                )
+            ack_id = audit_service.update_ack(
+                audit, ack_id,
+                f'\u23f3 Running {trigger_kw.lstrip("@")} audit\u2026',
+            )
 
             last_err = None
             success = False
@@ -261,10 +219,7 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event, trigger_config,
                 if attempt > 0:
                     set_audit_context(attempt=attempt + 1)
                 try:
-                    if use_service:
-                        _run_audit_service(audit, ack_id, audit_service)
-                    else:
-                        _run_audit_legacy(item, ack_id, trigger_config)
+                    _run_audit(audit, ack_id, audit_service)
                     ack_id = None
                     success = True
                     break
@@ -278,24 +233,14 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event, trigger_config,
                     if attempt >= max_attempts - 1:
                         break
                     backoff = _BACKOFFS[min(attempt, len(_BACKOFFS) - 1)]
-                    if use_service:
-                        ack_id = audit_service.update_ack(
-                            audit, ack_id,
-                            (
-                                f'\u23f3 {trigger_kw.lstrip("@")} audit hit a snag '
-                                f'({err}). Retrying in {backoff}s '
-                                f'(attempt {attempt + 2}/{max_attempts})\u2026'
-                            ),
-                        )
-                    else:
-                        ack_id = update_ack(
-                            item, ack_id,
-                            (
-                                f'\u23f3 {trigger_kw.lstrip("@")} audit hit a snag '
-                                f'({err}). Retrying in {backoff}s '
-                                f'(attempt {attempt + 2}/{max_attempts})\u2026'
-                            ),
-                        )
+                    ack_id = audit_service.update_ack(
+                        audit, ack_id,
+                        (
+                            f'\u23f3 {trigger_kw.lstrip("@")} audit hit a snag '
+                            f'({err}). Retrying in {backoff}s '
+                            f'(attempt {attempt + 2}/{max_attempts})\u2026'
+                        ),
+                    )
                     if stop_event.wait(timeout=backoff):
                         logger.info('shutdown during backoff — aborting retry')
                         break
@@ -304,10 +249,7 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event, trigger_config,
             total_seconds = time.monotonic() - queued.enqueued_at
 
             if success:
-                if use_service:
-                    audit_service.dispatch_events(audit, total_seconds)
-                else:
-                    record_audit_completed(total_seconds, 'success')
+                audit_service.dispatch_events(audit, total_seconds)
                 logger.info(
                     '\u2705 audit.completed',
                     extra={
@@ -318,32 +260,18 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event, trigger_config,
                     },
                 )
             else:
-                if use_service:
-                    audit_service.delete_ack(audit, ack_id)
-                    try:
-                        audit_service.post_reply(
-                            audit,
-                            (
-                                f'Audit failed after {max_attempts} attempts.\n'
-                                f'Last error: {last_err}\n\n{_EM_DASH} FigWatch'
-                            ),
-                        )
-                    except Exception:
-                        logger.exception('error reply post failed')
-                    audit_service.dispatch_events(audit, total_seconds)
-                else:
-                    delete_ack(item, ack_id)
-                    try:
-                        post_reply(
-                            item,
-                            (
-                                f'Audit failed after {max_attempts} attempts.\n'
-                                f'Last error: {last_err}\n\n{_EM_DASH} FigWatch'
-                            ),
-                        )
-                    except Exception:
-                        logger.exception('error reply post failed')
-                    record_audit_completed(total_seconds, 'failed')
+                audit_service.delete_ack(audit, ack_id)
+                try:
+                    audit_service.post_reply(
+                        audit,
+                        (
+                            f'Audit failed after {max_attempts} attempts.\n'
+                            f'Last error: {last_err}\n\n{_EM_DASH} FigWatch'
+                        ),
+                    )
+                except Exception:
+                    logger.exception('error reply post failed')
+                audit_service.dispatch_events(audit, total_seconds)
                 logger.error(
                     '\u274c audit.failed',
                     extra={
@@ -363,10 +291,10 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event, trigger_config,
 
 # ── HTTP handler ───────────────────────────────────────────────────────
 
-def _make_handler(pat, passcode, allowed_file_keys, locale, model, claude_path,
+def _make_handler(pat, passcode, allowed_file_keys,
                   trigger_config, processed_ids, processed_lock, work_queue,
                   ack_updater: AckUpdater, received_events, received_lock,
-                  audit_service: AuditService = None):
+                  audit_service: AuditService):
     class WebhookHandler(BaseHTTPRequestHandler):
         def do_GET(self):
             if self.path == '/health':
@@ -430,73 +358,53 @@ def _make_handler(pat, passcode, allowed_file_keys, locale, model, claude_path,
                     return
                 processed_ids.add(comment_id)
 
-            item, reason = _build_work_item(
+            audit_id = new_audit_id()
+            audit, reason = _build_audit(
                 payload, comment_id, pat, allowed_file_keys,
-                locale, model, claude_path, trigger_config,
+                trigger_config, audit_id,
             )
 
-            if item is None:
+            if audit is None:
                 logger.debug('skip', extra={'reason': reason})
                 self._respond(200, reason)
                 return
 
             save_processed(processed_ids)
 
-            audit_id = new_audit_id()
-
-            # Build Audit aggregate alongside legacy WorkItem
-            comment_obj = payload.get('comment') or {}
-            message = comment_obj.get('message') or comment_obj.get('text', '')
-            trigger_match = match_trigger(message, trigger_config)
-            audit_obj = Audit(
-                audit_id=audit_id,
-                comment=Comment(
-                    comment_id=str(comment_id),
-                    message=message,
-                    parent_id=item.reply_to_id if item.reply_to_id != str(comment_id) else None,
-                    node_id=item.node_id,
-                    user_handle=item.user_handle,
-                    file_key=item.file_key,
-                ),
-                trigger_match=trigger_match,
-            )
+            trigger_kw = audit.trigger_match.trigger.keyword
 
             # Temporarily set context so the ack post + enqueue log lines
             # carry the new audit_id. Cleared on next request.
             set_audit_context(
                 audit=audit_id,
-                trigger=item.trigger,
-                node=item.node_id,
+                trigger=trigger_kw,
+                node=audit.comment.node_id,
                 file=file_key,
             )
 
             logger.info(
                 '\U0001f4ac trigger matched',
-                extra={'user': item.user_handle},
+                extra={'user': audit.comment.user_handle},
             )
 
             ahead = work_queue.depth
             if ahead == 0:
                 queue_msg = (
-                    f'\u23f3 {item.trigger.lstrip("@")} audit queued '
+                    f'\u23f3 {trigger_kw.lstrip("@")} audit queued '
                     f'\u2014 starting shortly\u2026'
                 )
             else:
                 queue_msg = (
-                    f'\u23f3 {item.trigger.lstrip("@")} audit queued '
+                    f'\u23f3 {trigger_kw.lstrip("@")} audit queued '
                     f'({ahead} ahead of you)\u2026'
                 )
 
-            if audit_service:
-                ack_id = audit_service.post_ack(audit_obj, queue_msg)
-            else:
-                ack_id = post_ack(item, queue_msg)
+            ack_id = audit_service.post_ack(audit, queue_msg)
 
             queued = QueuedItem(
-                item=item,
+                audit=audit,
                 ack_id=ack_id,
                 audit_id=audit_id,
-                audit=audit_obj,
             )
             work_queue.put(queued)
             record_queue_change(1)
@@ -648,7 +556,7 @@ def main():
     work_queue = InstrumentedQueue()
     stop_event = threading.Event()
 
-    ack_updater = AckUpdater(work_queue, rate_per_minute=queue_update_rpm)
+    ack_updater = AckUpdater(work_queue, comment_repo, rate_per_minute=queue_update_rpm)
     ack_updater.start()
 
     logger.info(
@@ -665,7 +573,7 @@ def main():
     worker_threads = [
         threading.Thread(
             target=_worker_loop,
-            args=(work_queue, stop_event, trigger_config, max_attempts,
+            args=(work_queue, stop_event, max_attempts,
                   ack_updater, audit_service),
             name=f'figwatch-worker-{i}',
             daemon=True,
@@ -677,7 +585,6 @@ def main():
 
     handler = _make_handler(
         pat, passcode, allowed_file_keys,
-        locale, model, claude_path,
         trigger_config, processed_ids, processed_lock, work_queue,
         ack_updater, received_events, received_lock,
         audit_service,

--- a/tests/test_ack_updater.py
+++ b/tests/test_ack_updater.py
@@ -1,66 +1,66 @@
 """Tests for figwatch.ack_updater — AckUpdater background worker.
 
-These tests stub out the real Figma API (post_ack / delete_ack) by
-monkeypatching the ack_updater module so no network calls happen.
+These tests use a FakeCommentRepository to avoid network calls.
 """
 
 import threading
 import time
-from types import SimpleNamespace
 
 import pytest
 
 from figwatch.ack_updater import AckUpdater, PendingUpdate, _position_message
+from figwatch.domain import Audit, Comment, Trigger, TriggerMatch
 from figwatch.queue_stats import InstrumentedQueue, QueuedItem
 
 
 # ── Helpers ───────────────────────────────────────────────────────────
 
-def _make_item(trigger='@ux', node_id='1:2', file_key='abc'):
-    return SimpleNamespace(
-        trigger=trigger,
-        node_id=node_id,
-        file_key=file_key,
-        reply_to_id='111',
-        pat='figd_test',
+def _make_audit(trigger='@ux', node_id='1:2', file_key='abc'):
+    return Audit(
+        audit_id='test',
+        comment=Comment(
+            comment_id='c1', message=f'{trigger} check', parent_id='111',
+            node_id=node_id, user_handle='alice', file_key=file_key,
+        ),
+        trigger_match=TriggerMatch(
+            trigger=Trigger(keyword=trigger, skill_ref='builtin:ux'),
+            extra='',
+        ),
     )
 
 
 def _queued(audit_id, ack_id='ack-0'):
     return QueuedItem(
-        item=_make_item(),
+        audit=_make_audit(),
         ack_id=ack_id,
         audit_id=audit_id,
     )
 
 
-class _AckStub:
-    """Monkeypatch target that records delete/post calls and hands out
-    predictable ack ids.
-    """
+class FakeCommentRepo:
+    """Records post/delete calls and hands out predictable ack ids."""
 
     def __init__(self):
         self.posts = []
         self.deletes = []
         self._counter = 0
 
-    def post_ack(self, item, message):
+    def post_reply(self, file_key, parent_comment_id, message):
         self._counter += 1
         new_id = f'ack-{self._counter}'
-        self.posts.append({'item': item, 'message': message, 'ack_id': new_id})
+        self.posts.append({'message': message, 'ack_id': new_id})
         return new_id
 
-    def delete_ack(self, item, ack_id):
-        if ack_id is not None:
-            self.deletes.append({'item': item, 'ack_id': ack_id})
+    def delete_comment(self, file_key, comment_id):
+        self.deletes.append({'comment_id': comment_id})
+
+    def fetch_comments(self, file_key):
+        return []
 
 
 @pytest.fixture
-def stub(monkeypatch):
-    s = _AckStub()
-    monkeypatch.setattr('figwatch.ack_updater.post_ack', s.post_ack)
-    monkeypatch.setattr('figwatch.ack_updater.delete_ack', s.delete_ack)
-    return s
+def repo():
+    return FakeCommentRepo()
 
 
 # ── _position_message formatting ─────────────────────────────────────
@@ -86,25 +86,25 @@ def test_position_message_strips_trigger_prefix():
 
 # ── Public API surface ───────────────────────────────────────────────
 
-def test_track_initial_records_position():
+def test_track_initial_records_position(repo):
     q = InstrumentedQueue()
-    updater = AckUpdater(q, rate_per_minute=60, poll_seconds=0.01)
+    updater = AckUpdater(q, repo, rate_per_minute=60, poll_seconds=0.01)
     updater.track_initial('abc', position=3)
     assert updater._displayed['abc'] == 3
 
 
-def test_cancel_removes_tracking():
+def test_cancel_removes_tracking(repo):
     q = InstrumentedQueue()
-    updater = AckUpdater(q, rate_per_minute=60, poll_seconds=0.01)
+    updater = AckUpdater(q, repo, rate_per_minute=60, poll_seconds=0.01)
     updater.track_initial('abc', position=2)
     updater.cancel('abc')
     assert 'abc' not in updater._displayed
     assert 'abc' not in updater._pending
 
 
-def test_rate_zero_disables_thread():
+def test_rate_zero_disables_thread(repo):
     q = InstrumentedQueue()
-    updater = AckUpdater(q, rate_per_minute=0)
+    updater = AckUpdater(q, repo, rate_per_minute=0)
     updater.start()
     assert updater._thread is None
     updater.stop()
@@ -112,13 +112,13 @@ def test_rate_zero_disables_thread():
 
 # ── _refresh_pending (position change detection) ─────────────────────
 
-def test_refresh_skips_items_at_their_displayed_position(stub):
+def test_refresh_skips_items_at_their_displayed_position(repo):
     q = InstrumentedQueue()
     q.put(_queued('a'))
     q.put(_queued('b'))
     q.put(_queued('c'))
 
-    updater = AckUpdater(q, rate_per_minute=60, poll_seconds=0.01)
+    updater = AckUpdater(q, repo, rate_per_minute=60, poll_seconds=0.01)
     updater.track_initial('a', position=0)
     updater.track_initial('b', position=1)
     updater.track_initial('c', position=2)
@@ -127,13 +127,13 @@ def test_refresh_skips_items_at_their_displayed_position(stub):
     assert updater._pending == {}
 
 
-def test_refresh_schedules_update_when_position_moves(stub):
+def test_refresh_schedules_update_when_position_moves(repo):
     q = InstrumentedQueue()
     q.put(_queued('a'))
     q.put(_queued('b'))
     q.put(_queued('c'))
 
-    updater = AckUpdater(q, rate_per_minute=60, poll_seconds=0.01)
+    updater = AckUpdater(q, repo, rate_per_minute=60, poll_seconds=0.01)
     updater.track_initial('a', position=0)
     updater.track_initial('b', position=1)
     updater.track_initial('c', position=2)
@@ -148,42 +148,37 @@ def test_refresh_schedules_update_when_position_moves(stub):
     assert updater._pending['c'].new_position == 1
 
 
-def test_refresh_coalesces_multiple_updates_for_same_audit(stub):
+def test_refresh_coalesces_multiple_updates_for_same_audit(repo):
     q = InstrumentedQueue()
     q.put(_queued('a'))
     q.put(_queued('b'))
     q.put(_queued('c'))
     q.put(_queued('d'))
 
-    updater = AckUpdater(q, rate_per_minute=60, poll_seconds=0.01)
+    updater = AckUpdater(q, repo, rate_per_minute=60, poll_seconds=0.01)
     updater.track_initial('a', position=0)
     updater.track_initial('b', position=1)
     updater.track_initial('c', position=2)
     updater.track_initial('d', position=3)
 
-    # First refresh: nothing pending
     updater._refresh_pending()
     assert updater._pending == {}
 
-    # Remove 'a' — d moves from position 3 to 2
     q.get(timeout=1)
     updater._refresh_pending()
     assert updater._pending['d'].new_position == 2
 
-    # Remove 'b' — d moves from 2 to 1 BEFORE the previous update fires
     q.get(timeout=1)
     updater._refresh_pending()
-    # Only one entry for 'd', and it holds the latest position (1)
     assert updater._pending['d'].new_position == 1
 
 
-def test_refresh_cleans_up_stale_displayed_entries(stub):
+def test_refresh_cleans_up_stale_displayed_entries(repo):
     q = InstrumentedQueue()
     q.put(_queued('a'))
 
-    updater = AckUpdater(q, rate_per_minute=60, poll_seconds=0.01)
+    updater = AckUpdater(q, repo, rate_per_minute=60, poll_seconds=0.01)
     updater.track_initial('a', position=0)
-    # Simulate a stale entry for an item that's already gone from the queue
     updater._displayed['ghost'] = 2
     updater._pending['ghost'] = PendingUpdate(
         audit_id='ghost', new_position=1, queued=_queued('ghost'),
@@ -196,57 +191,52 @@ def test_refresh_cleans_up_stale_displayed_entries(stub):
 
 # ── _post_one (actual ack update posting) ────────────────────────────
 
-def test_post_one_posts_pending_update(stub):
+def test_post_one_posts_pending_update(repo):
     q = InstrumentedQueue()
     queued = _queued('a', ack_id='ack-0')
     q.put(queued)
 
-    updater = AckUpdater(q, rate_per_minute=60, poll_seconds=0.01)
+    updater = AckUpdater(q, repo, rate_per_minute=60, poll_seconds=0.01)
     updater._pending['a'] = PendingUpdate(
         audit_id='a', new_position=2, queued=queued,
     )
 
     updater._post_one()
-    assert len(stub.posts) == 1
-    assert len(stub.deletes) == 1
-    assert stub.deletes[0]['ack_id'] == 'ack-0'
-    assert '2 ahead' in stub.posts[0]['message']
-    # ack_id rewritten on the QueuedItem
+    assert len(repo.posts) == 1
+    assert len(repo.deletes) == 1
+    assert repo.deletes[0]['comment_id'] == 'ack-0'
+    assert '2 ahead' in repo.posts[0]['message']
     assert queued.ack_id == 'ack-1'
-    # displayed position updated
     assert updater._displayed['a'] == 2
 
 
-def test_post_one_skips_if_audit_no_longer_queued(stub):
+def test_post_one_skips_if_audit_no_longer_queued(repo):
     q = InstrumentedQueue()
     queued = _queued('a')
-    # Don't put it in the queue — find('a') will return None
 
-    updater = AckUpdater(q, rate_per_minute=60, poll_seconds=0.01)
+    updater = AckUpdater(q, repo, rate_per_minute=60, poll_seconds=0.01)
     updater._pending['a'] = PendingUpdate(
         audit_id='a', new_position=1, queued=queued,
     )
 
     updater._post_one()
-    assert stub.posts == []
-    assert stub.deletes == []
+    assert repo.posts == []
+    assert repo.deletes == []
 
 
-def test_post_one_noops_when_pending_empty(stub):
+def test_post_one_noops_when_pending_empty(repo):
     q = InstrumentedQueue()
-    updater = AckUpdater(q, rate_per_minute=60, poll_seconds=0.01)
+    updater = AckUpdater(q, repo, rate_per_minute=60, poll_seconds=0.01)
     updater._post_one()
-    assert stub.posts == []
+    assert repo.posts == []
 
 
-def test_post_one_respects_rate_limit(stub):
+def test_post_one_respects_rate_limit(repo):
     q = InstrumentedQueue()
     for audit_id in ('a', 'b', 'c'):
         q.put(_queued(audit_id))
 
-    # Rate = 1 per minute, capacity = 1. First post consumes the token,
-    # second post should be throttled (re-queued).
-    updater = AckUpdater(q, rate_per_minute=1, poll_seconds=0.01)
+    updater = AckUpdater(q, repo, rate_per_minute=1, poll_seconds=0.01)
     updater._pending['a'] = PendingUpdate(
         audit_id='a', new_position=1, queued=q.find('a'),
     )
@@ -255,18 +245,18 @@ def test_post_one_respects_rate_limit(stub):
     )
 
     updater._post_one()
-    assert len(stub.posts) == 1
+    assert len(repo.posts) == 1
 
     updater._post_one()
-    assert len(stub.posts) == 1  # throttled
+    assert len(repo.posts) == 1  # throttled
     assert 'b' in updater._pending  # re-queued
 
 
 # ── End-to-end: start / stop thread ──────────────────────────────────
 
-def test_start_stop_thread_runs_cleanly(stub):
+def test_start_stop_thread_runs_cleanly(repo):
     q = InstrumentedQueue()
-    updater = AckUpdater(q, rate_per_minute=60, poll_seconds=0.01)
+    updater = AckUpdater(q, repo, rate_per_minute=60, poll_seconds=0.01)
     updater.start()
     assert updater._thread is not None
     assert updater._thread.is_alive()
@@ -274,33 +264,29 @@ def test_start_stop_thread_runs_cleanly(stub):
     assert updater._thread is None
 
 
-def test_thread_posts_updates_when_queue_moves(stub):
+def test_thread_posts_updates_when_queue_moves(repo):
     q = InstrumentedQueue()
     q.put(_queued('a'))
     q.put(_queued('b'))
     q.put(_queued('c'))
 
-    updater = AckUpdater(q, rate_per_minute=60, poll_seconds=0.01)
+    updater = AckUpdater(q, repo, rate_per_minute=60, poll_seconds=0.01)
     updater.track_initial('a', position=0)
     updater.track_initial('b', position=1)
     updater.track_initial('c', position=2)
     updater.start()
 
     try:
-        # Remove 'a' — positions shift
         q.get(timeout=1)
-        # Wait for the updater to notice and post updates
         deadline = time.monotonic() + 2
         while time.monotonic() < deadline:
-            if len(stub.posts) >= 2:
+            if len(repo.posts) >= 2:
                 break
             time.sleep(0.02)
     finally:
         updater.stop()
 
-    assert len(stub.posts) >= 2
-    positions = [p['message'] for p in stub.posts]
-    # Expect one post for b (position 0 → 'starting shortly') and one for c
-    # (position 1 → '1 ahead of you')
+    assert len(repo.posts) >= 2
+    positions = [p['message'] for p in repo.posts]
     assert any('starting shortly' in m for m in positions)
     assert any('1 ahead of you' in m for m in positions)

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -100,7 +100,7 @@ def test_comment_frozen():
 
 
 def test_audit_result_frozen():
-    r = AuditResult(reply_text="ok", provider_name="Claude", frame_name="Frame 1")
+    r = AuditResult(reply_text="ok")
     with pytest.raises(AttributeError):
         r.reply_text = "no"
 
@@ -165,7 +165,7 @@ def test_audit_start_processing():
 
 def test_audit_complete():
     audit = _make_audit()
-    result = AuditResult(reply_text="looks good", provider_name="Claude", frame_name="Frame 1")
+    result = AuditResult(reply_text="looks good")
     audit.complete(result)
     assert audit.status == AuditStatus.REPLIED
     events = audit.collect_events()

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -11,13 +11,8 @@ from figwatch.domain import (
     AuditStarted,
     AuditStatus,
     Comment,
-    STATUS_DETECTED,
-    STATUS_ERROR,
-    STATUS_PROCESSING,
-    STATUS_REPLIED,
     Trigger,
     TriggerMatch,
-    WorkItem,
     match_trigger,
 )
 
@@ -73,13 +68,14 @@ def test_match_trigger_returns_trigger_match():
     assert isinstance(result.trigger, Trigger)
 
 
-# ── Deprecated STATUS_* constants ────────────────────────────────────
+# ── AuditStatus enum ─────────────────────────────────────────────────
 
-def test_status_constants_match_enum():
-    assert STATUS_DETECTED == AuditStatus.DETECTED.value
-    assert STATUS_PROCESSING == AuditStatus.PROCESSING.value
-    assert STATUS_REPLIED == AuditStatus.REPLIED.value
-    assert STATUS_ERROR == AuditStatus.ERROR.value
+def test_audit_status_values():
+    assert AuditStatus.DETECTED.value == 'detected'
+    assert AuditStatus.QUEUED.value == 'queued'
+    assert AuditStatus.PROCESSING.value == 'processing'
+    assert AuditStatus.REPLIED.value == 'replied'
+    assert AuditStatus.ERROR.value == 'error'
 
 
 # ── Value objects (frozen) ───────────────────────────────────────────
@@ -195,26 +191,3 @@ def test_audit_collect_events_clears():
     assert audit.collect_events() == []
 
 
-# ── WorkItem (deprecated) ───────────────────────────────────────────
-
-def test_work_item_is_namedtuple():
-    item = WorkItem(
-        file_key="abc", comment_id="1", reply_to_id="1", node_id="2:3",
-        trigger="@ux", skill_path="builtin:ux", user_handle="alice", extra="",
-        locale="uk", model="gemini-flash", reply_lang="en", pat="figd_x",
-        claude_path="api", on_status=None,
-    )
-    assert item.file_key == "abc"
-    assert item.trigger == "@ux"
-
-
-def test_work_item_replace():
-    item = WorkItem(
-        file_key="abc", comment_id="1", reply_to_id="1", node_id="2:3",
-        trigger="@ux", skill_path="builtin:ux", user_handle="alice", extra="",
-        locale=None, model=None, reply_lang=None, pat="figd_x",
-        claude_path=None, on_status=None,
-    )
-    filled = item._replace(locale="uk", model="gemini-flash", reply_lang="en", claude_path="api")
-    assert filled.locale == "uk"
-    assert filled.model == "gemini-flash"

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1,14 +1,23 @@
-"""Tests for figwatch.domain — trigger matching and config loading."""
+"""Tests for figwatch.domain — trigger matching, value objects, and Audit aggregate."""
 
-import json
-import os
 import pytest
 
 from figwatch.domain import (
-    DEFAULT_TRIGGERS,
+    Audit,
+    AuditCompleted,
+    AuditFailed,
+    AuditQueued,
+    AuditResult,
+    AuditStarted,
+    AuditStatus,
+    Comment,
+    STATUS_DETECTED,
+    STATUS_ERROR,
+    STATUS_PROCESSING,
+    STATUS_REPLIED,
+    Trigger,
+    TriggerMatch,
     WorkItem,
-    _discover_custom_triggers,
-    load_trigger_config,
     match_trigger,
 )
 
@@ -23,26 +32,26 @@ TRIGGERS = [
 
 def test_match_trigger_exact():
     result = match_trigger("@ux", TRIGGERS)
-    assert result["trigger"] == "@ux"
-    assert result["skill"] == "builtin:ux"
-    assert result["extra"] == ""
+    assert result.trigger.keyword == "@ux"
+    assert result.trigger.skill_ref == "builtin:ux"
+    assert result.extra == ""
 
 
 def test_match_trigger_with_extra():
     result = match_trigger("@ux please check the nav", TRIGGERS)
-    assert result["trigger"] == "@ux"
-    assert result["extra"] == "please check the nav"
+    assert result.trigger.keyword == "@ux"
+    assert result.extra == "please check the nav"
 
 
 def test_match_trigger_mid_message():
     result = match_trigger("hey can you @tone this screen", TRIGGERS)
-    assert result["trigger"] == "@tone"
+    assert result.trigger.keyword == "@tone"
 
 
 def test_match_trigger_case_insensitive():
     result = match_trigger("@UX audit this", TRIGGERS)
     assert result is not None
-    assert result["trigger"] == "@ux"
+    assert result.trigger.keyword == "@ux"
 
 
 def test_match_trigger_no_match():
@@ -54,82 +63,139 @@ def test_match_trigger_empty_message():
 
 
 def test_match_trigger_first_wins():
-    # @ux appears before @tone in config — should match @ux
     result = match_trigger("@ux @tone", TRIGGERS)
-    assert result["trigger"] == "@ux"
+    assert result.trigger.keyword == "@ux"
 
 
-# ── load_trigger_config ───────────────────────────────────────────────
-
-def test_load_trigger_config_defaults_when_no_config(tmp_path, monkeypatch):
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.chdir(tmp_path)
-    config = load_trigger_config()
-    assert config == DEFAULT_TRIGGERS
+def test_match_trigger_returns_trigger_match():
+    result = match_trigger("@ux check this", TRIGGERS)
+    assert isinstance(result, TriggerMatch)
+    assert isinstance(result.trigger, Trigger)
 
 
-def test_load_trigger_config_from_file(tmp_path, monkeypatch):
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.chdir(tmp_path)
-    figwatch_dir = tmp_path / ".figwatch"
-    figwatch_dir.mkdir()
-    config_data = {"triggers": [{"trigger": "@a11y", "skill": "/skills/a11y.md"}]}
-    (figwatch_dir / "config.json").write_text(json.dumps(config_data))
+# ── Deprecated STATUS_* constants ────────────────────────────────────
 
-    config = load_trigger_config()
-    assert any(t["trigger"] == "@a11y" for t in config)
+def test_status_constants_match_enum():
+    assert STATUS_DETECTED == AuditStatus.DETECTED.value
+    assert STATUS_PROCESSING == AuditStatus.PROCESSING.value
+    assert STATUS_REPLIED == AuditStatus.REPLIED.value
+    assert STATUS_ERROR == AuditStatus.ERROR.value
 
 
-def test_load_trigger_config_discovers_custom_skills(tmp_path, monkeypatch):
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.chdir(tmp_path)
-    custom_dir = tmp_path / "custom-skills"
-    custom_dir.mkdir()
-    (custom_dir / "brand.md").write_text("# Brand skill")
+# ── Value objects (frozen) ───────────────────────────────────────────
 
-    config = load_trigger_config()
-    assert any(t["trigger"] == "@brand" for t in config)
+def test_trigger_frozen():
+    t = Trigger(keyword="@ux", skill_ref="builtin:ux")
+    with pytest.raises(AttributeError):
+        t.keyword = "@tone"
 
 
-def test_load_trigger_config_custom_skill_subdir(tmp_path, monkeypatch):
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.chdir(tmp_path)
-    skill_dir = tmp_path / "custom-skills" / "motion"
-    skill_dir.mkdir(parents=True)
-    (skill_dir / "skill.md").write_text("# Motion skill")
-
-    config = load_trigger_config()
-    assert any(t["trigger"] == "@motion" for t in config)
+def test_trigger_match_frozen():
+    tm = TriggerMatch(trigger=Trigger(keyword="@ux", skill_ref="builtin:ux"), extra="")
+    with pytest.raises(AttributeError):
+        tm.extra = "new"
 
 
-# ── FIGWATCH_SKILLS_DIR ─────────────────────────────────────────────
-
-def test_discover_custom_triggers_explicit_dir(tmp_path):
-    skills = tmp_path / "my-skills"
-    skills.mkdir()
-    (skills / "perf.md").write_text("# Perf skill")
-
-    triggers = _discover_custom_triggers(str(skills))
-    assert any(t["trigger"] == "@perf" for t in triggers)
+def test_comment_frozen():
+    c = Comment(comment_id="1", message="hi", parent_id=None,
+                node_id="2:3", user_handle="alice", file_key="abc")
+    with pytest.raises(AttributeError):
+        c.message = "bye"
 
 
-def test_load_trigger_config_with_skills_dir(tmp_path, monkeypatch):
-    monkeypatch.setenv("HOME", str(tmp_path))
-    skills = tmp_path / "my-skills"
-    skills.mkdir()
-    (skills / "perf.md").write_text("# Perf skill")
-
-    config = load_trigger_config(skills_dir=str(skills))
-    assert any(t["trigger"] == "@perf" for t in config)
+def test_audit_result_frozen():
+    r = AuditResult(reply_text="ok", provider_name="Claude", frame_name="Frame 1")
+    with pytest.raises(AttributeError):
+        r.reply_text = "no"
 
 
-def test_discover_custom_triggers_explicit_dir_missing(tmp_path):
-    """Non-existent explicit dir returns empty (caller validates at startup)."""
-    triggers = _discover_custom_triggers(str(tmp_path / "nope"))
-    assert triggers == []
+# ── Audit aggregate ─────────────────────────────────────────────────
+
+def _make_audit(audit_id="audit-1"):
+    return Audit(
+        audit_id=audit_id,
+        comment=Comment(
+            comment_id="c1", message="@ux check", parent_id="p1",
+            node_id="2:3", user_handle="alice", file_key="abc",
+        ),
+        trigger_match=TriggerMatch(
+            trigger=Trigger(keyword="@ux", skill_ref="builtin:ux"),
+            extra="check",
+        ),
+    )
 
 
-# ── WorkItem ──────────────────────────────────────────────────────────
+def test_audit_initial_status():
+    audit = _make_audit()
+    assert audit.status == AuditStatus.DETECTED
+
+
+def test_audit_reply_to_id_with_parent():
+    audit = _make_audit()
+    assert audit.reply_to_id == "p1"
+
+
+def test_audit_reply_to_id_without_parent():
+    audit = Audit(
+        audit_id="a1",
+        comment=Comment(
+            comment_id="c1", message="@ux", parent_id=None,
+            node_id="2:3", user_handle="alice", file_key="abc",
+        ),
+        trigger_match=TriggerMatch(
+            trigger=Trigger(keyword="@ux", skill_ref="builtin:ux"), extra="",
+        ),
+    )
+    assert audit.reply_to_id == "c1"
+
+
+def test_audit_queue_transition():
+    audit = _make_audit()
+    audit.queue()
+    assert audit.status == AuditStatus.QUEUED
+    events = audit.collect_events()
+    assert len(events) == 1
+    assert isinstance(events[0], AuditQueued)
+    assert events[0].audit_id == "audit-1"
+
+
+def test_audit_start_processing():
+    audit = _make_audit()
+    audit.start_processing()
+    assert audit.status == AuditStatus.PROCESSING
+    events = audit.collect_events()
+    assert isinstance(events[0], AuditStarted)
+
+
+def test_audit_complete():
+    audit = _make_audit()
+    result = AuditResult(reply_text="looks good", provider_name="Claude", frame_name="Frame 1")
+    audit.complete(result)
+    assert audit.status == AuditStatus.REPLIED
+    events = audit.collect_events()
+    assert isinstance(events[0], AuditCompleted)
+    assert events[0].result == result
+
+
+def test_audit_fail():
+    audit = _make_audit()
+    audit.fail("timeout")
+    assert audit.status == AuditStatus.ERROR
+    events = audit.collect_events()
+    assert isinstance(events[0], AuditFailed)
+    assert events[0].error == "timeout"
+
+
+def test_audit_collect_events_clears():
+    audit = _make_audit()
+    audit.queue()
+    audit.start_processing()
+    events = audit.collect_events()
+    assert len(events) == 2
+    assert audit.collect_events() == []
+
+
+# ── WorkItem (deprecated) ───────────────────────────────────────────
 
 def test_work_item_is_namedtuple():
     item = WorkItem(

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -1,0 +1,79 @@
+"""Tests for figwatch.ports — repository protocols and Figma implementations."""
+
+from unittest.mock import patch
+
+from figwatch.ports import CommentRepository, DesignDataRepository
+from figwatch.providers.figma import FigmaCommentRepository, FigmaDesignDataRepository
+
+
+# ── Protocol conformance ─────────────────────────────────────────────
+
+def test_figma_comment_repo_satisfies_protocol():
+    assert isinstance(FigmaCommentRepository('pat'), CommentRepository)
+
+
+def test_figma_design_data_repo_satisfies_protocol():
+    assert isinstance(FigmaDesignDataRepository('pat'), DesignDataRepository)
+
+
+# ── FigmaCommentRepository ───────────────────────────────────────────
+
+@patch('figwatch.providers.figma.figma_post')
+def test_post_reply_returns_id(mock_post):
+    mock_post.return_value = {'id': 'comment-42'}
+    repo = FigmaCommentRepository('test-pat')
+    result = repo.post_reply('file-1', 'parent-1', 'hello')
+    assert result == 'comment-42'
+    mock_post.assert_called_once_with(
+        '/files/file-1/comments',
+        {'message': 'hello', 'comment_id': 'parent-1'},
+        'test-pat',
+    )
+
+
+@patch('figwatch.providers.figma.figma_post')
+def test_post_reply_returns_none_on_error(mock_post):
+    mock_post.side_effect = Exception('network error')
+    repo = FigmaCommentRepository('test-pat')
+    assert repo.post_reply('f', 'p', 'msg') is None
+
+
+@patch('figwatch.providers.figma.figma_delete')
+def test_delete_comment_calls_api(mock_delete):
+    repo = FigmaCommentRepository('test-pat')
+    repo.delete_comment('file-1', 'comment-1')
+    mock_delete.assert_called_once_with('/files/file-1/comments/comment-1', 'test-pat')
+
+
+@patch('figwatch.providers.figma.figma_delete')
+def test_delete_comment_silent_on_error(mock_delete):
+    mock_delete.side_effect = Exception('gone')
+    repo = FigmaCommentRepository('test-pat')
+    repo.delete_comment('f', 'c')  # should not raise
+
+
+@patch('figwatch.providers.figma.figma_get')
+def test_fetch_comments(mock_get):
+    mock_get.return_value = {'comments': [{'id': '1'}, {'id': '2'}]}
+    repo = FigmaCommentRepository('test-pat')
+    result = repo.fetch_comments('file-1')
+    assert len(result) == 2
+
+
+@patch('figwatch.providers.figma.figma_get')
+def test_fetch_comments_empty_on_none(mock_get):
+    mock_get.return_value = None
+    repo = FigmaCommentRepository('test-pat')
+    assert repo.fetch_comments('f') == []
+
+
+# ── FigmaDesignDataRepository ────────────────────────────────────────
+
+@patch('figwatch.providers.figma.fetch_figma_data')
+def test_design_data_repo_delegates(mock_fetch):
+    mock_fetch.return_value = ({'screenshot': '/tmp/s.png'}, {'name': 'Frame'})
+    repo = FigmaDesignDataRepository('test-pat')
+    data, tree = repo.fetch(['screenshot'], 'file-1', '2:3')
+    assert data == {'screenshot': '/tmp/s.png'}
+    assert tree == {'name': 'Frame'}
+    mock_fetch.assert_called_once_with(['screenshot'], 'file-1', '2:3', 'test-pat')

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from figwatch.ports import CommentRepository, DesignDataRepository
 from figwatch.providers.figma import FigmaCommentRepository, FigmaDesignDataRepository
 
@@ -32,10 +34,11 @@ def test_post_reply_returns_id(mock_post):
 
 
 @patch('figwatch.providers.figma.figma_post')
-def test_post_reply_returns_none_on_error(mock_post):
+def test_post_reply_raises_on_error(mock_post):
     mock_post.side_effect = Exception('network error')
     repo = FigmaCommentRepository('test-pat')
-    assert repo.post_reply('f', 'p', 'msg') is None
+    with pytest.raises(Exception, match='network error'):
+        repo.post_reply('f', 'p', 'msg')
 
 
 @patch('figwatch.providers.figma.figma_delete')

--- a/tests/test_queue_stats.py
+++ b/tests/test_queue_stats.py
@@ -9,7 +9,7 @@ from figwatch.queue_stats import InstrumentedQueue, QueuedItem
 
 
 def _queued(audit_id='a3f9', attempt=1):
-    return QueuedItem(item='stub', ack_id=None, audit_id=audit_id, attempt=attempt)
+    return QueuedItem(audit='stub', ack_id=None, audit_id=audit_id, attempt=attempt)
 
 
 # ── Basic put / get ──────────────────────────────────────────────────
@@ -128,7 +128,7 @@ def test_stats_snapshot_does_not_share_state():
 # ── QueuedItem ───────────────────────────────────────────────────────
 
 def test_queued_item_defaults():
-    item = QueuedItem(item='work', ack_id=None, audit_id='a3f9')
+    item = QueuedItem(audit='work', ack_id=None, audit_id='a3f9')
     assert item.attempt == 1
     assert item.waited_seconds == 0.0
     assert item.enqueued_at > 0

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,168 @@
+"""Tests for figwatch.services — AuditService application layer."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from figwatch.domain import (
+    Audit, AuditCompleted, AuditFailed, AuditResult, AuditStatus,
+    Comment, Trigger, TriggerMatch,
+)
+from figwatch.services import AuditConfig, AuditService
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+def _make_audit(audit_id="audit-1"):
+    return Audit(
+        audit_id=audit_id,
+        comment=Comment(
+            comment_id="c1", message="@ux check", parent_id="p1",
+            node_id="2:3", user_handle="alice", file_key="file-1",
+        ),
+        trigger_match=TriggerMatch(
+            trigger=Trigger(keyword="@ux", skill_ref="builtin:ux"),
+            extra="check",
+        ),
+    )
+
+
+def _make_config():
+    return AuditConfig(model="gemini-flash", claude_path="api",
+                       reply_lang="en", locale="uk")
+
+
+def _make_service(comment_repo=None, design_repo=None, config=None):
+    return AuditService(
+        comment_repo=comment_repo or MagicMock(),
+        design_repo=design_repo or MagicMock(),
+        config=config or _make_config(),
+        trigger_config=[{"trigger": "@ux", "skill": "builtin:ux"}],
+    )
+
+
+# ── Ack lifecycle ────────────────────────────────────────────────────
+
+def test_post_ack_calls_repo():
+    repo = MagicMock()
+    repo.post_reply.return_value = "ack-42"
+    service = _make_service(comment_repo=repo)
+    audit = _make_audit()
+
+    result = service.post_ack(audit, "hello")
+    assert result == "ack-42"
+    repo.post_reply.assert_called_once_with("file-1", "p1", "hello")
+
+
+def test_delete_ack_calls_repo():
+    repo = MagicMock()
+    service = _make_service(comment_repo=repo)
+    audit = _make_audit()
+
+    service.delete_ack(audit, "ack-1")
+    repo.delete_comment.assert_called_once_with("file-1", "ack-1")
+
+
+def test_delete_ack_skips_none():
+    repo = MagicMock()
+    service = _make_service(comment_repo=repo)
+    audit = _make_audit()
+
+    service.delete_ack(audit, None)
+    repo.delete_comment.assert_not_called()
+
+
+def test_update_ack_deletes_then_posts():
+    repo = MagicMock()
+    repo.post_reply.return_value = "new-ack"
+    service = _make_service(comment_repo=repo)
+    audit = _make_audit()
+
+    result = service.update_ack(audit, "old-ack", "new message")
+    assert result == "new-ack"
+    repo.delete_comment.assert_called_once()
+    repo.post_reply.assert_called_once()
+
+
+# ── Execute ──────────────────────────────────────────────────────────
+
+@patch('figwatch.skills.execute_skill')
+def test_execute_success(mock_skill):
+    mock_skill.return_value = "Looks great!"
+    service = _make_service()
+    audit = _make_audit()
+
+    result = service.execute(audit)
+    assert "Looks great!" in result
+    assert audit.status == AuditStatus.REPLIED
+    events = audit.collect_events()
+    assert any(isinstance(e, AuditCompleted) for e in events)
+
+
+@patch('figwatch.skills.execute_skill')
+def test_execute_failure(mock_skill):
+    mock_skill.side_effect = RuntimeError("AI provider down")
+    service = _make_service()
+    audit = _make_audit()
+
+    with pytest.raises(RuntimeError):
+        service.execute(audit)
+    assert audit.status == AuditStatus.ERROR
+    events = audit.collect_events()
+    assert any(isinstance(e, AuditFailed) for e in events)
+
+
+@patch('figwatch.skills.execute_skill')
+def test_execute_passes_config_and_repo(mock_skill):
+    mock_skill.return_value = "ok"
+    design_repo = MagicMock()
+    config = _make_config()
+    service = _make_service(design_repo=design_repo, config=config)
+    audit = _make_audit()
+
+    service.execute(audit)
+    mock_skill.assert_called_once_with(
+        audit, config=config, design_repo=design_repo,
+    )
+
+
+# ── Event dispatch ───────────────────────────────────────────────────
+
+@patch('figwatch.metrics.record_audit_completed')
+@patch('figwatch.skills.execute_skill')
+def test_dispatch_events_success(mock_skill, mock_record):
+    mock_skill.return_value = "ok"
+    service = _make_service()
+    audit = _make_audit()
+    service.execute(audit)
+
+    service.dispatch_events(audit, duration=5.0)
+    mock_record.assert_called_once_with(5.0, 'success')
+
+
+@patch('figwatch.metrics.record_audit_completed')
+@patch('figwatch.skills.execute_skill')
+def test_dispatch_events_failure(mock_skill, mock_record):
+    mock_skill.side_effect = RuntimeError("boom")
+    service = _make_service()
+    audit = _make_audit()
+
+    with pytest.raises(RuntimeError):
+        service.execute(audit)
+
+    service.dispatch_events(audit, duration=3.0)
+    mock_record.assert_called_once_with(3.0, 'failed')
+
+
+# ── Config ───────────────────────────────────────────────────────────
+
+def test_audit_config_frozen():
+    config = _make_config()
+    with pytest.raises(AttributeError):
+        config.model = "opus"
+
+
+def test_service_exposes_config():
+    config = _make_config()
+    service = _make_service(config=config)
+    assert service.config is config

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -4,21 +4,40 @@ import json
 import os
 import pytest
 
-from figwatch.domain import WorkItem
+from figwatch.domain import Audit, Comment, Trigger, TriggerMatch
+from figwatch.services import AuditConfig
 from figwatch.skills import _build_prompt, find_skills, _resolve_builtin_skill
 
 
 # ── Helpers ───────────────────────────────────────────────────────────
 
-def _make_item(**kwargs):
+def _make_audit(**kwargs):
     defaults = dict(
-        file_key="abc", comment_id="1", reply_to_id="1", node_id="2:3",
-        trigger="@ux", skill_path="builtin:ux", user_handle="alice", extra="",
-        locale="uk", model="gemini-flash", reply_lang="en", pat="figd_x",
-        claude_path="api", on_status=None,
+        trigger_keyword="@ux", skill_ref="builtin:ux",
+        extra="", reply_lang="en",
     )
     defaults.update(kwargs)
-    return WorkItem(**defaults)
+    return Audit(
+        audit_id="test-1",
+        comment=Comment(
+            comment_id="1", message="@ux check", parent_id="1",
+            node_id="2:3", user_handle="alice", file_key="abc",
+        ),
+        trigger_match=TriggerMatch(
+            trigger=Trigger(
+                keyword=defaults["trigger_keyword"],
+                skill_ref=defaults["skill_ref"],
+            ),
+            extra=defaults["extra"],
+        ),
+    )
+
+
+def _make_config(**kwargs):
+    defaults = dict(model="gemini-flash", claude_path="api",
+                    reply_lang="en", locale="uk")
+    defaults.update(kwargs)
+    return AuditConfig(**defaults)
 
 
 SKILL_CONTENT = "# UX Skill\nEvaluate usability."
@@ -30,103 +49,129 @@ FRAME_NAME = "Home Screen"
 # ── _build_prompt ─────────────────────────────────────────────────────
 
 def test_build_prompt_contains_skill_content():
-    item = _make_item()
+    audit = _make_audit()
+    config = _make_config()
     data = {"screenshot": "/tmp/shot.png", "node_tree": "/tmp/tree.json"}
-    prompt = _build_prompt(item, SKILL_CONTENT, REFS, data, TREE_DATA, FRAME_NAME, inline_files=True)
+    prompt = _build_prompt(audit, SKILL_CONTENT, REFS, data, TREE_DATA, FRAME_NAME,
+                           inline_files=True, config=config)
     assert SKILL_CONTENT in prompt
 
 
 def test_build_prompt_inline_screenshot():
-    item = _make_item()
+    audit = _make_audit()
+    config = _make_config()
     data = {"screenshot": "/tmp/shot.png"}
-    prompt = _build_prompt(item, SKILL_CONTENT, REFS, data, TREE_DATA, FRAME_NAME, inline_files=True)
+    prompt = _build_prompt(audit, SKILL_CONTENT, REFS, data, TREE_DATA, FRAME_NAME,
+                           inline_files=True, config=config)
     assert "attached as image" in prompt
     assert "/tmp/shot.png" not in prompt
 
 
 def test_build_prompt_file_path_screenshot():
-    item = _make_item()
+    audit = _make_audit()
+    config = _make_config()
     data = {"screenshot": "/tmp/shot.png"}
-    prompt = _build_prompt(item, SKILL_CONTENT, REFS, data, TREE_DATA, FRAME_NAME, inline_files=False)
+    prompt = _build_prompt(audit, SKILL_CONTENT, REFS, data, TREE_DATA, FRAME_NAME,
+                           inline_files=False, config=config)
     assert "/tmp/shot.png" in prompt
     assert "attached as image" not in prompt
 
 
 def test_build_prompt_inline_tree_data_embedded():
-    item = _make_item()
+    audit = _make_audit()
+    config = _make_config()
     data = {"node_tree": "/tmp/tree.json"}
-    prompt = _build_prompt(item, SKILL_CONTENT, REFS, data, TREE_DATA, FRAME_NAME, inline_files=True)
-    assert "Home Screen" in prompt  # tree_data name embedded
+    prompt = _build_prompt(audit, SKILL_CONTENT, REFS, data, TREE_DATA, FRAME_NAME,
+                           inline_files=True, config=config)
+    assert "Home Screen" in prompt
 
 
 def test_build_prompt_file_path_tree_passes_path():
-    item = _make_item()
+    audit = _make_audit()
+    config = _make_config()
     data = {"node_tree": "/tmp/tree.json"}
-    prompt = _build_prompt(item, SKILL_CONTENT, REFS, data, TREE_DATA, FRAME_NAME, inline_files=False)
+    prompt = _build_prompt(audit, SKILL_CONTENT, REFS, data, TREE_DATA, FRAME_NAME,
+                           inline_files=False, config=config)
     assert "/tmp/tree.json" in prompt
 
 
 def test_build_prompt_contains_frame_name():
-    item = _make_item()
+    audit = _make_audit()
+    config = _make_config()
     data = {}
-    prompt = _build_prompt(item, SKILL_CONTENT, REFS, data, None, "Checkout Flow", inline_files=True)
+    prompt = _build_prompt(audit, SKILL_CONTENT, REFS, data, None, "Checkout Flow",
+                           inline_files=True, config=config)
     assert "Checkout Flow" in prompt
 
 
 def test_build_prompt_contains_trigger():
-    item = _make_item(trigger="@tone")
+    audit = _make_audit(trigger_keyword="@tone")
+    config = _make_config()
     data = {}
-    prompt = _build_prompt(item, SKILL_CONTENT, REFS, data, None, FRAME_NAME, inline_files=True)
+    prompt = _build_prompt(audit, SKILL_CONTENT, REFS, data, None, FRAME_NAME,
+                           inline_files=True, config=config)
     assert "@tone" in prompt
 
 
 def test_build_prompt_includes_extra_context():
-    item = _make_item(extra="focus on the button colour")
+    audit = _make_audit(extra="focus on the button colour")
+    config = _make_config()
     data = {}
-    prompt = _build_prompt(item, SKILL_CONTENT, REFS, data, None, FRAME_NAME, inline_files=True)
+    prompt = _build_prompt(audit, SKILL_CONTENT, REFS, data, None, FRAME_NAME,
+                           inline_files=True, config=config)
     assert "focus on the button colour" in prompt
 
 
 def test_build_prompt_no_extra_context_when_empty():
-    item = _make_item(extra="")
+    audit = _make_audit(extra="")
+    config = _make_config()
     data = {}
-    prompt = _build_prompt(item, SKILL_CONTENT, REFS, data, None, FRAME_NAME, inline_files=True)
+    prompt = _build_prompt(audit, SKILL_CONTENT, REFS, data, None, FRAME_NAME,
+                           inline_files=True, config=config)
     assert "Additional context" not in prompt
 
 
 def test_build_prompt_chinese_instruction():
-    item = _make_item(reply_lang="cn")
+    audit = _make_audit()
+    config = _make_config(reply_lang="cn")
     data = {}
-    prompt = _build_prompt(item, SKILL_CONTENT, REFS, data, None, FRAME_NAME, inline_files=True)
+    prompt = _build_prompt(audit, SKILL_CONTENT, REFS, data, None, FRAME_NAME,
+                           inline_files=True, config=config)
     assert "Simplified Chinese" in prompt
 
 
 def test_build_prompt_no_chinese_instruction_by_default():
-    item = _make_item(reply_lang="en")
+    audit = _make_audit()
+    config = _make_config(reply_lang="en")
     data = {}
-    prompt = _build_prompt(item, SKILL_CONTENT, REFS, data, None, FRAME_NAME, inline_files=True)
+    prompt = _build_prompt(audit, SKILL_CONTENT, REFS, data, None, FRAME_NAME,
+                           inline_files=True, config=config)
     assert "Simplified Chinese" not in prompt
 
 
 def test_build_prompt_tree_truncated_when_large(monkeypatch):
     import figwatch.skills as skills_mod
     monkeypatch.setattr(skills_mod, "_NODE_TREE_CHAR_LIMIT", 10)
-    item = _make_item()
+    audit = _make_audit()
+    config = _make_config()
     big_tree = {"name": "Frame", "data": "x" * 100}
     data = {"node_tree": "/tmp/tree.json"}
-    prompt = _build_prompt(item, SKILL_CONTENT, REFS, data, big_tree, FRAME_NAME, inline_files=True)
+    prompt = _build_prompt(audit, SKILL_CONTENT, REFS, data, big_tree, FRAME_NAME,
+                           inline_files=True, config=config)
     assert "truncated" in prompt
 
 
 def test_build_prompt_text_nodes_listed():
-    item = _make_item()
+    audit = _make_audit()
+    config = _make_config()
     data = {
         "text_nodes": [
             {"name": "Heading", "text": "Welcome back"},
             {"name": "Body", "text": "Here is your dashboard"},
         ]
     }
-    prompt = _build_prompt(item, SKILL_CONTENT, REFS, data, None, FRAME_NAME, inline_files=True)
+    prompt = _build_prompt(audit, SKILL_CONTENT, REFS, data, None, FRAME_NAME,
+                           inline_files=True, config=config)
     assert "Welcome back" in prompt
     assert "Here is your dashboard" in prompt
 
@@ -141,7 +186,6 @@ def test_find_skills_returns_list():
 def test_find_skills_bundled_included():
     skills = find_skills()
     names = {s["name"] for s in skills}
-    # bundled skills directory should have at least ux and tone
     assert "ux" in names or "tone" in names
 
 

--- a/tests/test_trigger_config.py
+++ b/tests/test_trigger_config.py
@@ -1,0 +1,79 @@
+"""Tests for figwatch.trigger_config — config loading and custom skill discovery."""
+
+import json
+
+from figwatch.trigger_config import (
+    DEFAULT_TRIGGERS,
+    _discover_custom_triggers,
+    load_trigger_config,
+)
+
+
+# ── load_trigger_config ───────────────────────────────────────────────
+
+def test_load_trigger_config_defaults_when_no_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    config = load_trigger_config()
+    assert config == DEFAULT_TRIGGERS
+
+
+def test_load_trigger_config_from_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    figwatch_dir = tmp_path / ".figwatch"
+    figwatch_dir.mkdir()
+    config_data = {"triggers": [{"trigger": "@a11y", "skill": "/skills/a11y.md"}]}
+    (figwatch_dir / "config.json").write_text(json.dumps(config_data))
+
+    config = load_trigger_config()
+    assert any(t["trigger"] == "@a11y" for t in config)
+
+
+def test_load_trigger_config_discovers_custom_skills(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    custom_dir = tmp_path / "custom-skills"
+    custom_dir.mkdir()
+    (custom_dir / "brand.md").write_text("# Brand skill")
+
+    config = load_trigger_config()
+    assert any(t["trigger"] == "@brand" for t in config)
+
+
+def test_load_trigger_config_custom_skill_subdir(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    skill_dir = tmp_path / "custom-skills" / "motion"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "skill.md").write_text("# Motion skill")
+
+    config = load_trigger_config()
+    assert any(t["trigger"] == "@motion" for t in config)
+
+
+# ── FIGWATCH_SKILLS_DIR ─────────────────────────────────────────────
+
+def test_discover_custom_triggers_explicit_dir(tmp_path):
+    skills = tmp_path / "my-skills"
+    skills.mkdir()
+    (skills / "perf.md").write_text("# Perf skill")
+
+    triggers = _discover_custom_triggers(str(skills))
+    assert any(t["trigger"] == "@perf" for t in triggers)
+
+
+def test_load_trigger_config_with_skills_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    skills = tmp_path / "my-skills"
+    skills.mkdir()
+    (skills / "perf.md").write_text("# Perf skill")
+
+    config = load_trigger_config(skills_dir=str(skills))
+    assert any(t["trigger"] == "@perf" for t in config)
+
+
+def test_discover_custom_triggers_explicit_dir_missing(tmp_path):
+    """Non-existent explicit dir returns empty (caller validates at startup)."""
+    triggers = _discover_custom_triggers(str(tmp_path / "nope"))
+    assert triggers == []


### PR DESCRIPTION
## Summary

- Implement ADR-002: adopt tactical DDD patterns for the Comment Auditing bounded context
- Replace `WorkItem` namedtuple with `Audit` aggregate root, frozen value objects (`Trigger`, `TriggerMatch`, `Comment`, `AuditResult`), domain events, and `AuditStatus` enum
- Extract `figwatch/trigger_config.py` to make `domain.py` pure (no I/O)
- Add `CommentRepository` and `DesignDataRepository` protocols in `figwatch/ports.py` with Figma implementations
- Create `AuditService` application service with constructor-injected repositories
- Infrastructure credentials (`pat`) no longer threaded through domain objects — repositories hold them internally

Four incremental commits, each leaving the system fully functional:
1. Value objects, Audit aggregate, trigger config extraction
2. Repository protocols and Figma implementations
3. AuditService wiring in server.py
4. Remove WorkItem and all legacy patterns

## Test plan

- [x] All 232 existing + new tests pass (`pytest`)
- [x] Zero `WorkItem` references remain in codebase
- [x] `domain.py` has no I/O imports (`os`, `json`, `pathlib`)
- [x] No `item.pat` threading through domain objects
- [ ] Smoke test Docker server path (webhook → queue → skill → reply)
- [ ] Smoke test macOS menu bar app (poll → detect → audit → reply)