### PR TITLE
docs: domain logic Mermaid diagrams

### DIFF
--- a/docs/domain-logic.md
+++ b/docs/domain-logic.md
@@ -2,129 +2,123 @@
 
 How a Figma comment becomes an AI audit reply.
 
-## Producing an Audit
+## Audit Production
+
+A comment containing a trigger keyword (e.g. `@ux`, `@tone`) is matched to a **skill** — a markdown rubric that tells the AI what to evaluate and how. The skill declares what design data it needs, that data is fetched from Figma, and everything is assembled into a prompt for the AI provider.
 
 ```mermaid
 flowchart TD
-    %% ── Inputs ──────────────────────────────────────────
-    COMMENT["Figma Comment
-    ─────────────────
-    comment_id, message,
-    parent_id, node_id,
-    user_handle, file_key"]
+    COMMENT["💬 Figma Comment
+    ───────────────────
+    '@ux check the spacing
+    on this card layout'"]
 
-    TRIGGER_CFG["Trigger Config
-    ─────────────────
-    keyword → skill_ref
-    e.g. @ux → builtin:ux"]
+    COMMENT --> MATCH["Match trigger keyword"]
+    MATCH --> SKILL
 
-    %% ── Trigger matching ────────────────────────────────
-    COMMENT --> MATCH[match_trigger]
-    TRIGGER_CFG --> MATCH
-    MATCH -->|No keyword found| IGNORE([Ignored])
-    MATCH -->|Match| TM
+    SKILL["📋 Skill
+    ───────────────────
+    Evaluation rubric
+    written in markdown
 
-    TM["TriggerMatch
-    ─────────────────
-    trigger: Trigger
-    extra: reviewer context"]
+    e.g. builtin:ux uses
+    Nielsen's 10 Heuristics"]
 
-    %% ── Audit created ───────────────────────────────────
-    COMMENT --> AUDIT
-    TM --> AUDIT
-    AUDIT["Audit ∎ aggregate root
-    ──────────────────────
-    audit_id, comment,
-    trigger_match, status"]
+    SKILL --> INTROSPECT["Determine required data"]
 
-    %% ── Skill resolution ────────────────────────────────
-    AUDIT --> RESOLVE[Resolve skill_ref]
-    RESOLVE --> SKILL_FILE
+    INTROSPECT --> DATA
 
-    SKILL_FILE["skill.md
-    ─────────────────
-    evaluation rubric
-    + references/*.md"]
+    subgraph Design Data from Figma
+        DATA["What the skill asked for"]
 
-    %% ── Introspection ───────────────────────────────────
-    SKILL_FILE --> INTROSPECT[Introspect skill]
-    INTROSPECT --> REQ_DATA
+        SCREENSHOT["🖼️ Screenshot
+        Visual capture of the frame"]
 
-    REQ_DATA["required_data
-    ─────────────────
-    e.g. screenshot,
-    node_tree, text_nodes"]
+        NODE_TREE["🌳 Node Tree
+        Full layer hierarchy as JSON —
+        frame structure, auto-layout,
+        constraints, component instances"]
 
-    %% ── Figma data fetch ────────────────────────────────
-    REQ_DATA --> FETCH[Fetch from Figma API]
-    AUDIT --> FETCH
+        TEXT_NODES["📝 Text Nodes
+        Every text layer extracted
+        with its content and name"]
 
-    FETCH --> DESIGN_DATA
+        STYLES["🎨 Styles
+        Colour, typography, and
+        effect styles in the file"]
 
-    DESIGN_DATA["Design Data
-    ─────────────────
-    screenshot · node_tree
-    text_nodes · styles
-    components · variables
-    annotations · prototype_flows
-    dev_resources · file_structure"]
+        COMPONENTS["🧩 Components
+        Component definitions
+        used in the file"]
 
-    %% ── Prompt assembly ─────────────────────────────────
-    SKILL_FILE --> PROMPT[Build prompt]
-    DESIGN_DATA --> PROMPT
-    AUDIT --> PROMPT
+        VARIABLES["📐 Variables
+        Design tokens — spacing,
+        colour, and sizing values"]
 
-    PROMPT --> ASSEMBLED
+        ANNOTATIONS["📌 Annotations
+        Designer notes attached
+        to specific nodes"]
 
-    ASSEMBLED["Assembled Prompt
-    ─────────────────
-    skill instructions
-    + reference docs
-    + frame name
-    + trigger context
-    + design data
-    + output constraints"]
+        PROTOTYPES["🔗 Prototype Flows
+        Screen-to-screen navigation
+        connections and interactions"]
 
-    %% ── AI call ─────────────────────────────────────────
-    ASSEMBLED --> AI[AI Provider]
-    AI --> RAW[Raw reply text]
+        DEV_RESOURCES["🔧 Dev Resources
+        Links and assets attached
+        to nodes for developers"]
 
-    %% ── Post-processing ─────────────────────────────────
-    RAW --> CLEAN[clean_reply]
-    TRIGGER_CFG --> CLEAN
-    CLEAN --> REPLY
+        FILE_STRUCTURE["📂 File Structure
+        Top-level pages and
+        frame organisation"]
 
-    REPLY["Audit Reply
-    ─────────────────
-    🗣️ @ux Audit — Frame Name
+        DATA --- SCREENSHOT
+        DATA --- NODE_TREE
+        DATA --- TEXT_NODES
+        DATA --- STYLES
+        DATA --- COMPONENTS
+        DATA --- VARIABLES
+        DATA --- ANNOTATIONS
+        DATA --- PROTOTYPES
+        DATA --- DEV_RESOURCES
+        DATA --- FILE_STRUCTURE
+    end
 
-    plain-text evaluation
-    ≤4000 chars, no markdown,
-    trigger words stripped
+    SCREENSHOT --> PROMPT
+    NODE_TREE --> PROMPT
+    TEXT_NODES --> PROMPT
+    STYLES --> PROMPT
+    COMPONENTS --> PROMPT
+    VARIABLES --> PROMPT
+    ANNOTATIONS --> PROMPT
+    PROTOTYPES --> PROMPT
+    DEV_RESOURCES --> PROMPT
+    FILE_STRUCTURE --> PROMPT
+    SKILL --> PROMPT
 
-    — Provider Name"]
+    PROMPT["Assemble Prompt
+    ───────────────────
+    Skill rubric
+    + reference documents
+    + reviewer's extra context
+    + selected design data"]
 
-    %% ── Posted ──────────────────────────────────────────
-    REPLY --> POST[Post to Figma as comment reply]
+    PROMPT --> AI["AI Provider evaluates
+    against the skill rubric"]
 
-    %% ── Styling ─────────────────────────────────────────
-    classDef input fill:#e8f4fd,stroke:#4a90d9
-    classDef vo fill:#f0f0f0,stroke:#888
-    classDef process fill:#fff,stroke:#333
-    classDef output fill:#e8fde8,stroke:#4a9
-    classDef discard fill:#fafafa,stroke:#ccc,color:#999
+    AI --> REPLY
 
-    class COMMENT,TRIGGER_CFG,SKILL_FILE,DESIGN_DATA input
-    class TM,REQ_DATA,ASSEMBLED vo
-    class MATCH,RESOLVE,INTROSPECT,FETCH,PROMPT,AI,CLEAN,POST process
-    class AUDIT,REPLY output
-    class IGNORE discard
+    REPLY["💬 Audit Reply
+    ───────────────────
+    Plain-text evaluation
+    posted as a Figma
+    comment reply"]
 ```
 
-### Key concepts
+### Builtin skills
 
-- **Trigger matching** is a pure function — lowercase keyword search against the comment message. The text after the keyword becomes `extra` context passed to the AI.
-- **Skill introspection** determines what Figma data the skill needs. Builtin skills have hardcoded requirements; custom skills are analysed by a cheap AI model (Haiku/Flash) and cached by file mtime.
-- **Design data** is fetched in parallel from the Figma REST API (up to 3 concurrent requests). Screenshots try progressively smaller sizes until under 3.75 MB.
-- **Prompt assembly** embeds all data inline for API providers, or passes file paths for Claude CLI. Node tree JSON is capped at 40K characters.
-- **clean_reply** strips trigger keywords from the output (prevents feedback loops) and truncates to 4900 characters (Figma comment limit).
+| Skill | Trigger | What it evaluates | Data it needs |
+|-------|---------|-------------------|---------------|
+| **UX Heuristic Review** | `@ux` | Nielsen's 10 Usability Heuristics — cross-references the visual screenshot against the structural node tree | Screenshot, Node Tree |
+| **Tone of Voice Review** | `@tone` | Copy against locale-specific brand guidelines (DE, FR, NL, Benelux) with reference docs per locale | Node Tree, Text Nodes |
+
+Custom skills can be added as markdown files. Each skill is introspected to determine which design data types it requires — only the data it asks for is fetched.

--- a/docs/domain-logic.md
+++ b/docs/domain-logic.md
@@ -2,220 +2,129 @@
 
 How a Figma comment becomes an AI audit reply.
 
-## End-to-End Flow
+## Producing an Audit
 
 ```mermaid
 flowchart TD
-    subgraph Ingress
-        A[Figma FILE_COMMENT webhook] -->|POST /webhook| B[HTTP Handler]
-        B -->|HMAC-SHA256| C{Passcode valid?}
-        C -->|No| D[403 Forbidden]
-        C -->|Yes| E{Comment ID seen?}
-        E -->|Yes| F[200 OK — skip]
-        E -->|No| G[Parse payload]
-    end
+    %% ── Inputs ──────────────────────────────────────────
+    COMMENT["Figma Comment
+    ─────────────────
+    comment_id, message,
+    parent_id, node_id,
+    user_handle, file_key"]
 
-    subgraph Trigger Matching
-        G --> H[match_trigger]
-        H -->|No match| I[200 OK — ignore]
-        H -->|TriggerMatch| J[_build_audit]
-        J -->|File not in allowlist| K[Skip]
-        J -->|Resolve node_id| L[Create Audit aggregate]
-    end
+    TRIGGER_CFG["Trigger Config
+    ─────────────────
+    keyword → skill_ref
+    e.g. @ux → builtin:ux"]
 
-    subgraph Queuing
-        L --> M[Post queue ack to Figma]
-        M --> N[Wrap in QueuedItem]
-        N --> O[Enqueue in InstrumentedQueue]
-        O --> P[200 OK]
-    end
+    %% ── Trigger matching ────────────────────────────────
+    COMMENT --> MATCH[match_trigger]
+    TRIGGER_CFG --> MATCH
+    MATCH -->|No keyword found| IGNORE([Ignored])
+    MATCH -->|Match| TM
 
-    subgraph Ack Updater Thread
-        O -.->|polls every 2s| Q[AckUpdater]
-        Q --> R{Position changed?}
-        R -->|Yes| S{Rate bucket has token?}
-        S -->|Yes| T[Post position update]
-        S -->|No| U[Wait for next tick]
-        R -->|No| U
-    end
+    TM["TriggerMatch
+    ─────────────────
+    trigger: Trigger
+    extra: reviewer context"]
 
-    subgraph Worker Threads
-        O -->|dequeue| V[Worker]
-        V --> W[Cancel ack updater]
-        W --> X[AuditService.execute]
-    end
+    %% ── Audit created ───────────────────────────────────
+    COMMENT --> AUDIT
+    TM --> AUDIT
+    AUDIT["Audit ∎ aggregate root
+    ──────────────────────
+    audit_id, comment,
+    trigger_match, status"]
 
-    subgraph Skill Execution
-        X --> Y[Introspect skill.md]
-        X --> Z[Fetch Figma data]
-        Y --> AA[_build_prompt]
-        Z --> AA
-        AA --> AB[AI Provider call]
-        AB --> AC[clean_reply]
-    end
+    %% ── Skill resolution ────────────────────────────────
+    AUDIT --> RESOLVE[Resolve skill_ref]
+    RESOLVE --> SKILL_FILE
 
-    subgraph Reply
-        AC --> AD[Post reply to Figma]
-        AD --> AE[Delete ack comment]
-        AE --> AF[Dispatch domain events]
-    end
+    SKILL_FILE["skill.md
+    ─────────────────
+    evaluation rubric
+    + references/*.md"]
 
-    subgraph Retry Logic
-        X -->|Error| AG{Attempts left?}
-        AG -->|Yes| AH[Backoff 30s/120s/300s]
-        AH --> X
-        AG -->|No| AI[audit.fail — AuditFailed event]
-    end
+    %% ── Introspection ───────────────────────────────────
+    SKILL_FILE --> INTROSPECT[Introspect skill]
+    INTROSPECT --> REQ_DATA
+
+    REQ_DATA["required_data
+    ─────────────────
+    e.g. screenshot,
+    node_tree, text_nodes"]
+
+    %% ── Figma data fetch ────────────────────────────────
+    REQ_DATA --> FETCH[Fetch from Figma API]
+    AUDIT --> FETCH
+
+    FETCH --> DESIGN_DATA
+
+    DESIGN_DATA["Design Data
+    ─────────────────
+    screenshot · node_tree
+    text_nodes · styles
+    components · variables
+    annotations · prototype_flows
+    dev_resources · file_structure"]
+
+    %% ── Prompt assembly ─────────────────────────────────
+    SKILL_FILE --> PROMPT[Build prompt]
+    DESIGN_DATA --> PROMPT
+    AUDIT --> PROMPT
+
+    PROMPT --> ASSEMBLED
+
+    ASSEMBLED["Assembled Prompt
+    ─────────────────
+    skill instructions
+    + reference docs
+    + frame name
+    + trigger context
+    + design data
+    + output constraints"]
+
+    %% ── AI call ─────────────────────────────────────────
+    ASSEMBLED --> AI[AI Provider]
+    AI --> RAW[Raw reply text]
+
+    %% ── Post-processing ─────────────────────────────────
+    RAW --> CLEAN[clean_reply]
+    TRIGGER_CFG --> CLEAN
+    CLEAN --> REPLY
+
+    REPLY["Audit Reply
+    ─────────────────
+    🗣️ @ux Audit — Frame Name
+
+    plain-text evaluation
+    ≤4000 chars, no markdown,
+    trigger words stripped
+
+    — Provider Name"]
+
+    %% ── Posted ──────────────────────────────────────────
+    REPLY --> POST[Post to Figma as comment reply]
+
+    %% ── Styling ─────────────────────────────────────────
+    classDef input fill:#e8f4fd,stroke:#4a90d9
+    classDef vo fill:#f0f0f0,stroke:#888
+    classDef process fill:#fff,stroke:#333
+    classDef output fill:#e8fde8,stroke:#4a9
+    classDef discard fill:#fafafa,stroke:#ccc,color:#999
+
+    class COMMENT,TRIGGER_CFG,SKILL_FILE,DESIGN_DATA input
+    class TM,REQ_DATA,ASSEMBLED vo
+    class MATCH,RESOLVE,INTROSPECT,FETCH,PROMPT,AI,CLEAN,POST process
+    class AUDIT,REPLY output
+    class IGNORE discard
 ```
 
-## Audit Aggregate Lifecycle
+### Key concepts
 
-```mermaid
-stateDiagram-v2
-    [*] --> DETECTED : Audit created
-    DETECTED --> QUEUED : audit.queue()
-    QUEUED --> PROCESSING : audit.start_processing()
-    PROCESSING --> REPLIED : audit.complete(result)
-    PROCESSING --> ERROR : audit.fail(error)
-    ERROR --> PROCESSING : retry attempt
-
-    DETECTED --> DETECTED : TriggerDetected event
-    QUEUED --> QUEUED : AuditQueued event
-    PROCESSING --> PROCESSING : AuditStarted event
-    REPLIED --> [*] : AuditCompleted event
-    ERROR --> [*] : AuditFailed event
-```
-
-## Domain Model
-
-```mermaid
-classDiagram
-    class Audit {
-        <<Aggregate Root>>
-        +audit_id: str
-        +comment: Comment
-        +trigger_match: TriggerMatch
-        +status: AuditStatus
-        -_events: list[DomainEvent]
-        +queue()
-        +start_processing()
-        +complete(result: AuditResult)
-        +fail(error: str)
-        +collect_events() list[DomainEvent]
-    }
-
-    class Comment {
-        <<Value Object>>
-        +comment_id: str
-        +message: str
-        +parent_id: str?
-        +node_id: str
-        +user_handle: str
-        +file_key: str
-    }
-
-    class Trigger {
-        <<Value Object>>
-        +keyword: str
-        +skill_ref: str
-    }
-
-    class TriggerMatch {
-        <<Value Object>>
-        +trigger: Trigger
-        +extra: str
-    }
-
-    class AuditResult {
-        <<Value Object>>
-        +reply_text: str
-    }
-
-    class AuditStatus {
-        <<Enumeration>>
-        DETECTED
-        QUEUED
-        PROCESSING
-        REPLIED
-        ERROR
-    }
-
-    class DomainEvent {
-        <<Abstract>>
-        +audit_id: str
-        +timestamp: datetime
-    }
-
-    Audit *-- Comment
-    Audit *-- TriggerMatch
-    TriggerMatch *-- Trigger
-    Audit --> AuditResult : completes with
-    Audit --> AuditStatus : has
-    Audit --> DomainEvent : emits
-```
-
-## Threading Model
-
-```mermaid
-flowchart LR
-    subgraph Main Thread
-        HTTP[HTTP Server]
-    end
-
-    subgraph Worker Pool
-        W1[Worker 1]
-        W2[Worker 2]
-        W3[Worker 3]
-        W4[Worker 4]
-    end
-
-    subgraph Background
-        ACK[AckUpdater]
-        MON[WebhookMonitor]
-    end
-
-    Q[(InstrumentedQueue)]
-
-    HTTP -->|enqueue| Q
-    Q -->|dequeue| W1
-    Q -->|dequeue| W2
-    Q -->|dequeue| W3
-    Q -->|dequeue| W4
-    Q -.->|poll positions| ACK
-    MON -.->|reconcile missed webhooks| HTTP
-```
-
-## Repository Boundaries
-
-```mermaid
-flowchart TD
-    subgraph Domain
-        AS[AuditService]
-    end
-
-    subgraph Ports
-        CR[CommentRepository protocol]
-        DR[DesignDataRepository protocol]
-    end
-
-    subgraph Infrastructure
-        FCR[FigmaCommentRepository]
-        FDR[FigmaDesignDataRepository]
-        AIP[AIProvider]
-    end
-
-    subgraph External
-        FAPI[Figma REST API]
-        GEM[Gemini API]
-        CLA[Claude API / CLI]
-    end
-
-    AS --> CR
-    AS --> DR
-    CR -.->|implements| FCR
-    DR -.->|implements| FDR
-    FCR --> FAPI
-    FDR --> FAPI
-    AIP --> GEM
-    AIP --> CLA
-```
+- **Trigger matching** is a pure function — lowercase keyword search against the comment message. The text after the keyword becomes `extra` context passed to the AI.
+- **Skill introspection** determines what Figma data the skill needs. Builtin skills have hardcoded requirements; custom skills are analysed by a cheap AI model (Haiku/Flash) and cached by file mtime.
+- **Design data** is fetched in parallel from the Figma REST API (up to 3 concurrent requests). Screenshots try progressively smaller sizes until under 3.75 MB.
+- **Prompt assembly** embeds all data inline for API providers, or passes file paths for Claude CLI. Node tree JSON is capped at 40K characters.
+- **clean_reply** strips trigger keywords from the output (prevents feedback loops) and truncates to 4900 characters (Figma comment limit).

--- a/docs/domain-logic.md
+++ b/docs/domain-logic.md
@@ -1,0 +1,221 @@
+# Domain Logic
+
+How a Figma comment becomes an AI audit reply.
+
+## End-to-End Flow
+
+```mermaid
+flowchart TD
+    subgraph Ingress
+        A[Figma FILE_COMMENT webhook] -->|POST /webhook| B[HTTP Handler]
+        B -->|HMAC-SHA256| C{Passcode valid?}
+        C -->|No| D[403 Forbidden]
+        C -->|Yes| E{Comment ID seen?}
+        E -->|Yes| F[200 OK — skip]
+        E -->|No| G[Parse payload]
+    end
+
+    subgraph Trigger Matching
+        G --> H[match_trigger]
+        H -->|No match| I[200 OK — ignore]
+        H -->|TriggerMatch| J[_build_audit]
+        J -->|File not in allowlist| K[Skip]
+        J -->|Resolve node_id| L[Create Audit aggregate]
+    end
+
+    subgraph Queuing
+        L --> M[Post queue ack to Figma]
+        M --> N[Wrap in QueuedItem]
+        N --> O[Enqueue in InstrumentedQueue]
+        O --> P[200 OK]
+    end
+
+    subgraph Ack Updater Thread
+        O -.->|polls every 2s| Q[AckUpdater]
+        Q --> R{Position changed?}
+        R -->|Yes| S{Rate bucket has token?}
+        S -->|Yes| T[Post position update]
+        S -->|No| U[Wait for next tick]
+        R -->|No| U
+    end
+
+    subgraph Worker Threads
+        O -->|dequeue| V[Worker]
+        V --> W[Cancel ack updater]
+        W --> X[AuditService.execute]
+    end
+
+    subgraph Skill Execution
+        X --> Y[Introspect skill.md]
+        X --> Z[Fetch Figma data]
+        Y --> AA[_build_prompt]
+        Z --> AA
+        AA --> AB[AI Provider call]
+        AB --> AC[clean_reply]
+    end
+
+    subgraph Reply
+        AC --> AD[Post reply to Figma]
+        AD --> AE[Delete ack comment]
+        AE --> AF[Dispatch domain events]
+    end
+
+    subgraph Retry Logic
+        X -->|Error| AG{Attempts left?}
+        AG -->|Yes| AH[Backoff 30s/120s/300s]
+        AH --> X
+        AG -->|No| AI[audit.fail — AuditFailed event]
+    end
+```
+
+## Audit Aggregate Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> DETECTED : Audit created
+    DETECTED --> QUEUED : audit.queue()
+    QUEUED --> PROCESSING : audit.start_processing()
+    PROCESSING --> REPLIED : audit.complete(result)
+    PROCESSING --> ERROR : audit.fail(error)
+    ERROR --> PROCESSING : retry attempt
+
+    DETECTED --> DETECTED : TriggerDetected event
+    QUEUED --> QUEUED : AuditQueued event
+    PROCESSING --> PROCESSING : AuditStarted event
+    REPLIED --> [*] : AuditCompleted event
+    ERROR --> [*] : AuditFailed event
+```
+
+## Domain Model
+
+```mermaid
+classDiagram
+    class Audit {
+        <<Aggregate Root>>
+        +audit_id: str
+        +comment: Comment
+        +trigger_match: TriggerMatch
+        +status: AuditStatus
+        -_events: list[DomainEvent]
+        +queue()
+        +start_processing()
+        +complete(result: AuditResult)
+        +fail(error: str)
+        +collect_events() list[DomainEvent]
+    }
+
+    class Comment {
+        <<Value Object>>
+        +comment_id: str
+        +message: str
+        +parent_id: str?
+        +node_id: str
+        +user_handle: str
+        +file_key: str
+    }
+
+    class Trigger {
+        <<Value Object>>
+        +keyword: str
+        +skill_ref: str
+    }
+
+    class TriggerMatch {
+        <<Value Object>>
+        +trigger: Trigger
+        +extra: str
+    }
+
+    class AuditResult {
+        <<Value Object>>
+        +reply_text: str
+    }
+
+    class AuditStatus {
+        <<Enumeration>>
+        DETECTED
+        QUEUED
+        PROCESSING
+        REPLIED
+        ERROR
+    }
+
+    class DomainEvent {
+        <<Abstract>>
+        +audit_id: str
+        +timestamp: datetime
+    }
+
+    Audit *-- Comment
+    Audit *-- TriggerMatch
+    TriggerMatch *-- Trigger
+    Audit --> AuditResult : completes with
+    Audit --> AuditStatus : has
+    Audit --> DomainEvent : emits
+```
+
+## Threading Model
+
+```mermaid
+flowchart LR
+    subgraph Main Thread
+        HTTP[HTTP Server]
+    end
+
+    subgraph Worker Pool
+        W1[Worker 1]
+        W2[Worker 2]
+        W3[Worker 3]
+        W4[Worker 4]
+    end
+
+    subgraph Background
+        ACK[AckUpdater]
+        MON[WebhookMonitor]
+    end
+
+    Q[(InstrumentedQueue)]
+
+    HTTP -->|enqueue| Q
+    Q -->|dequeue| W1
+    Q -->|dequeue| W2
+    Q -->|dequeue| W3
+    Q -->|dequeue| W4
+    Q -.->|poll positions| ACK
+    MON -.->|reconcile missed webhooks| HTTP
+```
+
+## Repository Boundaries
+
+```mermaid
+flowchart TD
+    subgraph Domain
+        AS[AuditService]
+    end
+
+    subgraph Ports
+        CR[CommentRepository protocol]
+        DR[DesignDataRepository protocol]
+    end
+
+    subgraph Infrastructure
+        FCR[FigmaCommentRepository]
+        FDR[FigmaDesignDataRepository]
+        AIP[AIProvider]
+    end
+
+    subgraph External
+        FAPI[Figma REST API]
+        GEM[Gemini API]
+        CLA[Claude API / CLI]
+    end
+
+    AS --> CR
+    AS --> DR
+    CR -.->|implements| FCR
+    DR -.->|implements| FDR
+    FCR --> FAPI
+    FDR --> FAPI
+    AIP --> GEM
+    AIP --> CLA
+```


### PR DESCRIPTION
## Summary
- Add `docs/domain-logic.md` with a Mermaid diagram documenting how an audit is produced
- Shows the full path from trigger comment → skill resolution → design data fetch → prompt assembly → AI evaluation → reply
- Expands all 10 design data types the system can pull from Figma (screenshot, node tree, text nodes, styles, components, variables, annotations, prototype flows, dev resources, file structure)
- Includes a table of builtin skills (`@ux`, `@tone`) with what they evaluate and what data they require

## Test plan
- [ ] Verify diagram renders correctly on GitHub (Mermaid supported natively)