### PR TITLE
feat: show exact model ID in audit reply signature

### DIFF
--- a/docs/adr/002-domain-driven-design.md
+++ b/docs/adr/002-domain-driven-design.md
@@ -40,7 +40,7 @@ FigWatch operates in a single bounded context: **Comment Auditing**.
 | **TriggerMatch** | `TriggerMatch` | Value object: result of matching a comment against triggers — includes the trigger, skill path, and extra context text. |
 | **Comment** | `Comment` | Value object: a Figma comment — ID, message text, parent ID, node ID, user handle, file key. Replaces untyped dict fields on `WorkItem`. |
 | **Skill** | `Skill` | Value object: what AI prompt to run — a reference (builtin or file path) and compatibility metadata. |
-| **AuditResult** | `AuditResult` | Value object: the AI provider's response text, provider name, and frame name. Replaces raw string returns. |
+| **AuditResult** | `AuditResult` | Value object: the AI provider's response text, model ID, and frame name. Replaces raw string returns. |
 | **AuditStatus** | `AuditStatus` | Enum replacing string constants: `DETECTED`, `QUEUED`, `PROCESSING`, `REPLIED`, `ERROR`. |
 
 The term "WorkItem" is retired in favour of "Audit" — it better reflects the domain ("we are auditing a design") and matches how log messages and user-facing ack messages already describe the operation.

--- a/figwatch/providers/ai/__init__.py
+++ b/figwatch/providers/ai/__init__.py
@@ -2,6 +2,7 @@
 
 All providers expose:
   .name         — display name used in sign-offs (e.g. 'Gemini', 'Claude')
+  .model_id     — resolved model identifier (e.g. 'claude-sonnet-4-6')
   .inline_files — True if prompt embeds data inline; False if it uses file paths
   .call(prompt, image_path) -> str
 """
@@ -79,6 +80,7 @@ def reset_limiters() -> None:
 @runtime_checkable
 class AIProvider(Protocol):
     name: str
+    model_id: str
     inline_files: bool
 
     def call(self, prompt: str, image_path: 'str | None') -> str:

--- a/figwatch/providers/ai/__init__.py
+++ b/figwatch/providers/ai/__init__.py
@@ -1,7 +1,6 @@
 """AI provider protocol and factory.
 
 All providers expose:
-  .name         — display name used in sign-offs (e.g. 'Gemini', 'Claude')
   .model_id     — resolved model identifier (e.g. 'claude-sonnet-4-6')
   .inline_files — True if prompt embeds data inline; False if it uses file paths
   .call(prompt, image_path) -> str
@@ -79,7 +78,6 @@ def reset_limiters() -> None:
 
 @runtime_checkable
 class AIProvider(Protocol):
-    name: str
     model_id: str
     inline_files: bool
 

--- a/figwatch/providers/ai/anthropic.py
+++ b/figwatch/providers/ai/anthropic.py
@@ -10,6 +10,7 @@ class AnthropicProvider:
     inline_files = True
 
     def __init__(self, model_name: str, api_key: str, rate_limiter=None):
+        self.model_id = model_name
         self._model_name = model_name
         self._api_key = api_key
         self._rate_limiter = rate_limiter

--- a/figwatch/providers/ai/anthropic.py
+++ b/figwatch/providers/ai/anthropic.py
@@ -6,7 +6,6 @@ from figwatch.providers.ai import with_retry
 
 
 class AnthropicProvider:
-    name = 'Claude'
     inline_files = True
 
     def __init__(self, model_name: str, api_key: str, rate_limiter=None):

--- a/figwatch/providers/ai/claude_cli.py
+++ b/figwatch/providers/ai/claude_cli.py
@@ -12,6 +12,7 @@ class ClaudeCLIProvider:
     inline_files = False
 
     def __init__(self, model: str, claude_path: str, skill_dir: str = ''):
+        self.model_id = model
         self._model = model
         self._claude_path = claude_path
         self._skill_dir = skill_dir

--- a/figwatch/providers/ai/claude_cli.py
+++ b/figwatch/providers/ai/claude_cli.py
@@ -8,7 +8,6 @@ _HOME = Path.home()
 
 
 class ClaudeCLIProvider:
-    name = 'Claude'
     inline_files = False
 
     def __init__(self, model: str, claude_path: str, skill_dir: str = ''):

--- a/figwatch/providers/ai/gemini.py
+++ b/figwatch/providers/ai/gemini.py
@@ -8,6 +8,7 @@ class GeminiProvider:
     inline_files = True
 
     def __init__(self, model_name: str, api_key: str, rate_limiter=None):
+        self.model_id = model_name
         self._model_name = model_name
         self._api_key = api_key
         self._rate_limiter = rate_limiter

--- a/figwatch/providers/ai/gemini.py
+++ b/figwatch/providers/ai/gemini.py
@@ -4,7 +4,6 @@ from figwatch.providers.ai import with_retry
 
 
 class GeminiProvider:
-    name = 'Gemini'
     inline_files = True
 
     def __init__(self, model_name: str, api_key: str, rate_limiter=None):

--- a/figwatch/skills.py
+++ b/figwatch/skills.py
@@ -332,7 +332,7 @@ def execute_skill(audit, *, config, design_repo):
     try:
         reply = provider.call(prompt, data.get('screenshot'))
         header = f'\U0001f5e3\ufe0f {trigger_kw} Audit \u2014 {frame_name}'
-        return f'{header}\n\n{reply}\n\n\u2014 {provider.name}'
+        return f'{header}\n\n{reply}\n\n\u2014 {provider.model_id}'
     finally:
         for key in ['screenshot', 'node_tree']:
             p = data.get(key)

--- a/figwatch/skills.py
+++ b/figwatch/skills.py
@@ -322,7 +322,7 @@ def execute_skill(audit, *, config, design_repo):
     provider = make_provider(model, claude_path, skill_dir=skill_dir)
     logger.debug(
         'calling ai provider',
-        extra={'provider': provider.name, 'frame': frame_name},
+        extra={'provider': provider.model_id, 'frame': frame_name},
     )
     prompt = _build_prompt(
         audit, skill_content, refs_section, data, tree_data, frame_name,

--- a/tests/test_providers_ai.py
+++ b/tests/test_providers_ai.py
@@ -66,19 +66,19 @@ def test_make_provider_cli_passes_skill_dir():
 
 def test_gemini_provider_properties():
     p = GeminiProvider("gemini-flash", "key")
-    assert p.name == "Gemini"
+    assert p.model_id == "gemini-flash"
     assert p.inline_files is True
 
 
 def test_anthropic_provider_properties():
     p = AnthropicProvider("claude-sonnet-4-6", "key")
-    assert p.name == "Claude"
+    assert p.model_id == "claude-sonnet-4-6"
     assert p.inline_files is True
 
 
 def test_claude_cli_provider_properties():
     p = ClaudeCLIProvider("sonnet", "claude")
-    assert p.name == "Claude"
+    assert p.model_id == "sonnet"
     assert p.inline_files is False
 
 


### PR DESCRIPTION
## Summary

- Adds `model_id` field to the `AIProvider` protocol and all concrete providers (Gemini, Anthropic API, Claude CLI)
- Audit reply sign-off now shows the resolved model identifier (e.g. `claude-sonnet-4-6`) instead of the generic display name (`Claude`)

Closes #31

## Test plan

- [x] All 232 existing tests pass
- [ ] Deploy and trigger an audit — verify sign-off shows e.g. `— claude-sonnet-4-6` instead of `— Claude`