### PR TITLE
feat: detect expired Figma token and fail fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           docker run -d --name figwatch-ci \
             -e FIGMA_PAT=figd_placeholder \
             -e FIGWATCH_WEBHOOK_PASSCODE=placeholder \
+            -e FIGWATCH_SKIP_TOKEN_CHECK=1 \
             -p 8080:8080 \
             figwatch:ci
           sleep 5

--- a/figwatch/metrics.py
+++ b/figwatch/metrics.py
@@ -23,6 +23,7 @@ _monitor_rotation_seconds = None
 _audit_duration = None
 _audit_total = None
 _queue_depth = None
+_token_expired = None
 
 
 def init_metrics(service_name='figwatch'):
@@ -33,7 +34,7 @@ def init_metrics(service_name='figwatch'):
     global _webhook_received, _webhook_missed, _webhook_last_received
     global _monitor_reconciliation, _monitor_comments_checked
     global _monitor_files_tracked, _monitor_rotation_seconds
-    global _audit_duration, _audit_total, _queue_depth
+    global _audit_duration, _audit_total, _queue_depth, _token_expired
 
     endpoint = os.environ.get('OTEL_EXPORTER_OTLP_ENDPOINT', '').strip()
     if not endpoint:
@@ -127,6 +128,11 @@ def init_metrics(service_name='figwatch'):
         description='Current queue depth',
     )
 
+    _token_expired = _meter.create_counter(
+        'figwatch.auth.token_expired',
+        description='Figma token expiry events detected',
+    )
+
     logger.info('OTel metrics initialised', extra={'endpoint': endpoint})
 
 
@@ -164,6 +170,11 @@ def record_audit_completed(duration_seconds, status):
         _audit_duration.record(duration_seconds)
     if _audit_total:
         _audit_total.add(1, {'status': status})
+
+
+def record_token_expired():
+    if _token_expired:
+        _token_expired.add(1)
 
 
 def record_queue_change(delta):

--- a/figwatch/providers/figma.py
+++ b/figwatch/providers/figma.py
@@ -15,6 +15,10 @@ logger = logging.getLogger(__name__)
 
 FIGMA_API = 'https://api.figma.com/v1'
 
+
+class FigmaTokenExpired(Exception):
+    """Raised when Figma returns 403 with 'Token expired'."""
+
 # Base64 adds ~33% overhead; cap raw bytes at 3.75 MB to stay under the 5 MB API limit.
 _MAX_IMAGE_BYTES = int(3.75 * 1024 * 1024)
 
@@ -25,6 +29,21 @@ def urllib_quote(s):
 
 # ── REST helpers ──────────────────────────────────────────────────────
 
+def _check_token_expired(e):
+    """Raise FigmaTokenExpired if an HTTPError is a 403 token-expiry response."""
+    if e.code != 403:
+        return
+    try:
+        body = json.loads(e.read())
+    except Exception:
+        return
+    if 'token expired' in str(body.get('err', '')).lower():
+        raise FigmaTokenExpired(
+            'Figma token expired — generate a new token at '
+            'https://www.figma.com/developers/api#access-tokens'
+        ) from e
+
+
 def _make_request(url, pat, method='GET', body=None):
     headers = {'X-Figma-Token': pat}
     data = None
@@ -32,10 +51,31 @@ def _make_request(url, pat, method='GET', body=None):
         headers['Content-Type'] = 'application/json'
         data = json.dumps(body).encode()
     req = urllib.request.Request(url, data=data, headers=headers, method=method)
-    with urllib.request.urlopen(req, timeout=15) as r:
-        if method == 'DELETE':
-            return None
-        return json.loads(r.read())
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            if method == 'DELETE':
+                return None
+            return json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        _check_token_expired(e)
+        raise
+
+
+def validate_token(pat):
+    """Check token validity against /v1/me. Returns user handle or raises.
+
+    Raises FigmaTokenExpired on expired token, RuntimeError on other failures.
+    """
+    try:
+        data = _make_request(f'{FIGMA_API}/me', pat)
+    except FigmaTokenExpired:
+        raise
+    except Exception as e:
+        raise RuntimeError(f'Figma token validation failed: {e}') from e
+    handle = (data or {}).get('handle')
+    if not handle:
+        raise RuntimeError('Figma token validation returned no user handle')
+    return handle
 
 
 def figma_get(path, pat):
@@ -53,6 +93,7 @@ def figma_delete(path, pat):
 def figma_get_retry(path, pat, retries=1, timeout=15):
     """GET a Figma API endpoint with retry on 429. Returns parsed JSON or None.
 
+    Raises FigmaTokenExpired immediately on 403 token-expiry (no retry).
     Raises socket.timeout / TimeoutError on timeout so callers can distinguish
     slow responses from other failures.
     """
@@ -65,6 +106,7 @@ def figma_get_retry(path, pat, retries=1, timeout=15):
             with urllib.request.urlopen(req, timeout=timeout) as r:
                 return json.loads(r.read())
         except urllib.error.HTTPError as e:
+            _check_token_expired(e)
             if e.code == 429 and attempt < retries:
                 try:
                     wait = int(e.headers.get('Retry-After', '0') or 0)

--- a/server.py
+++ b/server.py
@@ -66,11 +66,13 @@ from figwatch.log_context import (
 )
 from figwatch.logging_config import configure_logging
 from figwatch.metrics import (
-    init_metrics, record_queue_change, record_webhook_received,
+    init_metrics, record_queue_change, record_token_expired,
+    record_webhook_received,
 )
 from figwatch.providers.ai import CLAUDE_API_MODELS, GEMINI_MODELS
 from figwatch.providers.figma import (
-    FigmaCommentRepository, FigmaDesignDataRepository, figma_get_retry,
+    FigmaCommentRepository, FigmaDesignDataRepository, FigmaTokenExpired,
+    figma_get_retry, validate_token,
 )
 from figwatch.queue_stats import InstrumentedQueue, QueuedItem
 from figwatch.services import AuditConfig, AuditService
@@ -222,6 +224,14 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event,
                     _run_audit(audit, ack_id, audit_service)
                     ack_id = None
                     success = True
+                    break
+                except FigmaTokenExpired as err:
+                    last_err = err
+                    record_token_expired()
+                    logger.error(
+                        'Figma token expired — skipping retries',
+                        extra={'attempt': attempt + 1},
+                    )
                     break
                 except Exception as err:
                     last_err = err
@@ -448,6 +458,19 @@ def main():
         sys.exit(1)
     if not passcode:
         logger.error('FIGWATCH_WEBHOOK_PASSCODE is required')
+        sys.exit(1)
+
+    try:
+        handle = validate_token(pat)
+        logger.info('figma token valid', extra={'user': handle})
+    except FigmaTokenExpired:
+        logger.error(
+            'Figma token expired — generate a new token at '
+            'https://www.figma.com/developers/api#access-tokens'
+        )
+        sys.exit(1)
+    except Exception as e:
+        logger.error('Figma token validation failed', extra={'error': str(e)})
         sys.exit(1)
 
     files_str = os.environ.get('FIGWATCH_FILES', '').strip()

--- a/server.py
+++ b/server.py
@@ -32,6 +32,7 @@ Environment variables:
   FIGWATCH_LOG_LEVEL          Log level: DEBUG, INFO, WARNING, ERROR (default: INFO)
   FIGWATCH_LOG_FORMAT         Log format: text (default) or json
   FIGWATCH_SKILLS_DIR         Path to custom-skills directory (default: ./custom-skills)
+  FIGWATCH_SKIP_TOKEN_CHECK   Skip Figma token validation at startup (for CI)
 
   Webhook health monitoring (all optional):
   OTEL_EXPORTER_OTLP_ENDPOINT   OTel collector endpoint (metrics disabled if unset)
@@ -460,18 +461,21 @@ def main():
         logger.error('FIGWATCH_WEBHOOK_PASSCODE is required')
         sys.exit(1)
 
-    try:
-        handle = validate_token(pat)
-        logger.info('figma token valid', extra={'user': handle})
-    except FigmaTokenExpired:
-        logger.error(
-            'Figma token expired — generate a new token at '
-            'https://www.figma.com/developers/api#access-tokens'
-        )
-        sys.exit(1)
-    except Exception as e:
-        logger.error('Figma token validation failed', extra={'error': str(e)})
-        sys.exit(1)
+    if os.environ.get('FIGWATCH_SKIP_TOKEN_CHECK', '').strip().lower() in ('1', 'true', 'yes'):
+        logger.warning('FIGWATCH_SKIP_TOKEN_CHECK set — skipping Figma token validation')
+    else:
+        try:
+            handle = validate_token(pat)
+            logger.info('figma token valid', extra={'user': handle})
+        except FigmaTokenExpired:
+            logger.error(
+                'Figma token expired — generate a new token at '
+                'https://www.figma.com/developers/api#access-tokens'
+            )
+            sys.exit(1)
+        except Exception as e:
+            logger.error('Figma token validation failed', extra={'error': str(e)})
+            sys.exit(1)
 
     files_str = os.environ.get('FIGWATCH_FILES', '').strip()
     allowed_file_keys = _parse_file_keys(files_str) if files_str else set()

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -27,6 +27,7 @@ def _run_main(env):
     with mock.patch.dict('os.environ', env, clear=True), \
          mock.patch('server.configure_logging'), \
          mock.patch('server.init_metrics'), \
+         mock.patch('server.validate_token', return_value='testuser'), \
          mock.patch('server.load_trigger_config', return_value=[]), \
          mock.patch('server.load_processed', return_value=set()), \
          mock.patch('server.AckUpdater'), \
@@ -189,3 +190,26 @@ def test_monitor_rpm_zero_exits():
 
 def test_monitor_rpm_valid():
     _run_main(_env(FIGWATCH_MONITOR_RPM='10'))
+
+
+# ── FIGMA_PAT token validation at startup ───────────────────────────
+
+
+def test_expired_token_exits():
+    from figwatch.providers.figma import FigmaTokenExpired
+
+    with mock.patch.dict('os.environ', _VALID_ENV, clear=True), \
+         mock.patch('server.configure_logging'), \
+         mock.patch('server.validate_token', side_effect=FigmaTokenExpired('expired')):
+        import server
+        with pytest.raises(SystemExit):
+            server.main()
+
+
+def test_invalid_token_exits():
+    with mock.patch.dict('os.environ', _VALID_ENV, clear=True), \
+         mock.patch('server.configure_logging'), \
+         mock.patch('server.validate_token', side_effect=RuntimeError('bad token')):
+        import server
+        with pytest.raises(SystemExit):
+            server.main()

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -213,3 +213,7 @@ def test_invalid_token_exits():
         import server
         with pytest.raises(SystemExit):
             server.main()
+
+
+def test_skip_token_check():
+    _run_main(_env(FIGWATCH_SKIP_TOKEN_CHECK='1'))

--- a/tests/test_token_expired.py
+++ b/tests/test_token_expired.py
@@ -1,0 +1,163 @@
+"""Tests for Figma token expiry detection (#40)."""
+
+import io
+import json
+import urllib.error
+from unittest import mock
+
+import pytest
+
+from figwatch.providers.figma import (
+    FigmaTokenExpired,
+    _check_token_expired,
+    _make_request,
+    figma_get,
+    figma_get_retry,
+    figma_post,
+    figma_delete,
+    validate_token,
+)
+
+
+def _make_http_error(code, body_dict):
+    """Build a urllib HTTPError with a JSON body."""
+    body = json.dumps(body_dict).encode()
+    resp = io.BytesIO(body)
+    err = urllib.error.HTTPError(
+        url='https://api.figma.com/v1/me',
+        code=code,
+        msg='error',
+        hdrs={},
+        fp=resp,
+    )
+    return err
+
+
+# ── _check_token_expired ────────────────────────────────────────────
+
+
+def test_check_token_expired_raises_on_403_token_expired():
+    err = _make_http_error(403, {'status': 403, 'err': 'Token expired'})
+    with pytest.raises(FigmaTokenExpired, match='generate a new token'):
+        _check_token_expired(err)
+
+
+def test_check_token_expired_ignores_403_other_message():
+    err = _make_http_error(403, {'status': 403, 'err': 'Forbidden'})
+    _check_token_expired(err)  # should not raise
+
+
+def test_check_token_expired_ignores_non_403():
+    err = _make_http_error(500, {'status': 500, 'err': 'Token expired'})
+    _check_token_expired(err)  # should not raise
+
+
+def test_check_token_expired_handles_malformed_body():
+    err = urllib.error.HTTPError(
+        url='https://api.figma.com/v1/me',
+        code=403,
+        msg='error',
+        hdrs={},
+        fp=io.BytesIO(b'not json'),
+    )
+    _check_token_expired(err)  # should not raise
+
+
+# ── figma_get_retry — no retry on token expiry ──────────────────────
+
+
+def test_figma_get_retry_raises_token_expired_immediately():
+    """Token expiry should propagate without retry."""
+    call_count = 0
+
+    def fake_urlopen(req, timeout=None):
+        nonlocal call_count
+        call_count += 1
+        raise _make_http_error(403, {'status': 403, 'err': 'Token expired'})
+
+    with mock.patch('figwatch.providers.figma.urllib.request.urlopen', fake_urlopen):
+        with pytest.raises(FigmaTokenExpired):
+            figma_get_retry('/me', 'expired-pat', retries=3)
+
+    assert call_count == 1, 'should not retry on token expiry'
+
+
+# ── _make_request — token expiry detection ───────────────────────────
+
+
+def test_make_request_raises_token_expired():
+    def fake_urlopen(req, timeout=None):
+        raise _make_http_error(403, {'status': 403, 'err': 'Token expired'})
+
+    with mock.patch('figwatch.providers.figma.urllib.request.urlopen', fake_urlopen):
+        with pytest.raises(FigmaTokenExpired):
+            figma_get('/me', 'expired-pat')
+
+
+def test_make_request_post_raises_token_expired():
+    def fake_urlopen(req, timeout=None):
+        raise _make_http_error(403, {'status': 403, 'err': 'Token expired'})
+
+    with mock.patch('figwatch.providers.figma.urllib.request.urlopen', fake_urlopen):
+        with pytest.raises(FigmaTokenExpired):
+            figma_post('/files/abc/comments', {'message': 'hi'}, 'expired-pat')
+
+
+def test_make_request_delete_raises_token_expired():
+    def fake_urlopen(req, timeout=None):
+        raise _make_http_error(403, {'status': 403, 'err': 'Token expired'})
+
+    with mock.patch('figwatch.providers.figma.urllib.request.urlopen', fake_urlopen):
+        with pytest.raises(FigmaTokenExpired):
+            figma_delete('/files/abc/comments/1', 'expired-pat')
+
+
+def test_make_request_non_expired_403_still_raises_http_error():
+    def fake_urlopen(req, timeout=None):
+        raise _make_http_error(403, {'status': 403, 'err': 'Forbidden'})
+
+    with mock.patch('figwatch.providers.figma.urllib.request.urlopen', fake_urlopen):
+        with pytest.raises(urllib.error.HTTPError):
+            figma_get('/me', 'bad-pat')
+
+
+# ── validate_token ──────────────────────────────────────────────────
+
+
+def test_validate_token_success():
+    ctx = mock.MagicMock()
+    ctx.__enter__ = mock.Mock(return_value=ctx)
+    ctx.__exit__ = mock.Mock(return_value=False)
+    ctx.read.return_value = json.dumps({'handle': 'testuser'}).encode()
+
+    with mock.patch('figwatch.providers.figma.urllib.request.urlopen', return_value=ctx):
+        assert validate_token('good-pat') == 'testuser'
+
+
+def test_validate_token_expired():
+    def fake_urlopen(req, timeout=None):
+        raise _make_http_error(403, {'status': 403, 'err': 'Token expired'})
+
+    with mock.patch('figwatch.providers.figma.urllib.request.urlopen', fake_urlopen):
+        with pytest.raises(FigmaTokenExpired):
+            validate_token('expired-pat')
+
+
+def test_validate_token_no_handle():
+    ctx = mock.MagicMock()
+    ctx.__enter__ = mock.Mock(return_value=ctx)
+    ctx.__exit__ = mock.Mock(return_value=False)
+    ctx.read.return_value = json.dumps({}).encode()
+
+    with mock.patch('figwatch.providers.figma.urllib.request.urlopen', return_value=ctx):
+        with pytest.raises(RuntimeError, match='no user handle'):
+            validate_token('weird-pat')
+
+
+def test_validate_token_network_error():
+    def fake_urlopen(req, timeout=None):
+        raise ConnectionError('no network')
+
+    with mock.patch('figwatch.providers.figma.urllib.request.urlopen', fake_urlopen):
+        with pytest.raises(RuntimeError, match='validation failed'):
+            validate_token('offline-pat')


### PR DESCRIPTION
## Summary

Closes #40.

- **`FigmaTokenExpired` exception** — raised when Figma returns `403` + `"Token expired"`, detected in both `_make_request` and `figma_get_retry`
- **No retry on expiry** — `figma_get_retry` bails immediately (retries won't help), worker loop skips backoff
- **Startup validation** — `server.py:main()` calls `/v1/me` before accepting traffic, exits on expired/invalid token (ADR-001 fail-fast)
- **Metric** — `figwatch.auth.token_expired` counter emitted when worker hits token expiry
- **`validate_token(pat)`** — reusable helper for server and macOS app

## Test plan

- [x] `test_token_expired.py` — 13 tests covering `_check_token_expired`, `figma_get_retry` no-retry, `_make_request` propagation (GET/POST/DELETE), `validate_token` success/expired/no-handle/network-error
- [x] `test_server_config.py` — 2 new tests: expired token exits, invalid token exits
- [x] Full suite passes (247 tests)