### PR TITLE
feat: model Figma's tiered rate limiting

### DIFF
--- a/figwatch/providers/figma.py
+++ b/figwatch/providers/figma.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import re
 import socket
 import tempfile
 import time
@@ -10,6 +11,8 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor
+
+from figwatch.providers.ai.rate_limit import TokenBucket
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +28,81 @@ _MAX_IMAGE_BYTES = int(3.75 * 1024 * 1024)
 
 def urllib_quote(s):
     return urllib.parse.quote(s, safe='')
+
+
+# ── Figma rate limit tiers ───────────────────────────────────────────
+
+TIER_1 = 1  # Heavy: full file, nodes, image renders
+TIER_2 = 2  # Medium: comments, dev_resources, variables, projects
+TIER_3 = 3  # Light: styles, components, metadata
+
+_TIER_PATTERNS: list[tuple[str, int]] = [
+    # Tier 1
+    ('/images/', TIER_1),
+    ('/nodes', TIER_1),
+    # Tier 3 (check before generic fallback)
+    ('/styles', TIER_3),
+    ('/components', TIER_3),
+    ('/component_sets', TIER_3),
+    ('/meta', TIER_3),
+]
+
+# RPM budgets from Figma docs: (tier1, tier2, tier3)
+_RATE_LIMITS = {
+    'starter': (1, 5, 10),  # Tier 1 is 6/month — use 1 as floor
+    ('professional', 'view'): (1, 5, 10),
+    ('professional', 'dev'): (10, 25, 50),
+    ('organization', 'view'): (1, 5, 10),
+    ('organization', 'dev'): (15, 50, 100),
+    ('enterprise', 'view'): (1, 5, 10),
+    ('enterprise', 'dev'): (15, 50, 100),
+}
+
+
+def endpoint_tier(path: str) -> int:
+    """Determine Figma rate limit tier from API path."""
+    for pattern, tier in _TIER_PATTERNS:
+        if pattern in path:
+            return tier
+    # Bare /files/:key (with optional query string) = Tier 1
+    if re.search(r'/files/[^/]+(\?.*)?$', path):
+        return TIER_1
+    return TIER_2
+
+
+class FigmaRateLimiter:
+    """Three independent token buckets matching Figma's tiered rate limits."""
+
+    def __init__(self, plan: str, seat: str = 'dev'):
+        if plan == 'starter':
+            key = 'starter'
+        else:
+            key = (plan, seat)
+        if key not in _RATE_LIMITS:
+            raise ValueError(f'Unknown plan/seat combination: {key!r}')
+        tier1_rpm, tier2_rpm, tier3_rpm = _RATE_LIMITS[key]
+        self._buckets = {
+            TIER_1: TokenBucket(capacity=max(tier1_rpm, 1), refill_per_second=tier1_rpm / 60),
+            TIER_2: TokenBucket(capacity=tier2_rpm, refill_per_second=tier2_rpm / 60),
+            TIER_3: TokenBucket(capacity=tier3_rpm, refill_per_second=tier3_rpm / 60),
+        }
+
+    def acquire(self, path: str) -> None:
+        """Block until a token is available in the correct tier bucket."""
+        tier = endpoint_tier(path)
+        self._buckets[tier].acquire()
+
+    def backoff(self, path: str, retry_after: float) -> None:
+        """Drain the tier bucket after a 429, forcing other threads to wait.
+
+        Sets the bucket's token count to negative so threads must wait for
+        refill_rate * retry_after seconds before proceeding.
+        """
+        tier = endpoint_tier(path)
+        bucket = self._buckets[tier]
+        with bucket._lock:
+            # Drain tokens so subsequent acquires block for ~retry_after seconds
+            bucket._tokens = -(bucket._refill_rate * retry_after)
 
 
 # ── REST helpers ──────────────────────────────────────────────────────
@@ -90,13 +168,18 @@ def figma_delete(path, pat):
     _make_request(f'{FIGMA_API}{path}', pat, method='DELETE')
 
 
-def figma_get_retry(path, pat, retries=1, timeout=15):
+def figma_get_retry(path, pat, retries=1, timeout=15, limiter=None):
     """GET a Figma API endpoint with retry on 429. Returns parsed JSON or None.
 
     Raises FigmaTokenExpired immediately on 403 token-expiry (no retry).
     Raises socket.timeout / TimeoutError on timeout so callers can distinguish
     slow responses from other failures.
+
+    If *limiter* is provided, acquires from the appropriate tier bucket before
+    making the request.
     """
+    if limiter:
+        limiter.acquire(path)
     for attempt in range(retries + 1):
         try:
             req = urllib.request.Request(
@@ -112,11 +195,14 @@ def figma_get_retry(path, pat, retries=1, timeout=15):
                     wait = int(e.headers.get('Retry-After', '0') or 0)
                 except Exception:
                     wait = 0
+                wait = max(wait, 2)
+                if limiter:
+                    limiter.backoff(path, wait)
                 logger.warning(
                     'figma 429 — retrying',
-                    extra={'path': path, 'retry_in_seconds': max(wait, 2)},
+                    extra={'path': path, 'retry_in_seconds': wait},
                 )
-                time.sleep(max(wait, 2))
+                time.sleep(wait)
                 continue
             logger.warning('figma API error',
                            extra={'path': path, 'status': e.code})
@@ -198,7 +284,7 @@ def _extract_annotations(node):
 
 # ── Data fetching ─────────────────────────────────────────────────────
 
-def fetch_screenshot(file_key, node_id, pat):
+def fetch_screenshot(file_key, node_id, pat, limiter=None):
     """Download a Figma node screenshot. Returns file path or None.
 
     Tries progressively smaller PNG scales then falls back to JPEG. Returns None
@@ -220,6 +306,7 @@ def fetch_screenshot(file_key, node_id, pat):
                 f'/images/{file_key}?ids={enc_id}&scale={scale}&format={fmt}',
                 pat,
                 timeout=45,
+                limiter=limiter,
             )
             if not data or data.get('err') or data.get('status') == 400:
                 continue
@@ -245,11 +332,11 @@ def fetch_screenshot(file_key, node_id, pat):
     return None
 
 
-def fetch_node_tree(file_key, node_id, pat):
+def fetch_node_tree(file_key, node_id, pat, limiter=None):
     """Fetch the full node tree for a Figma node. Returns (file_path, parsed_data) or (None, None)."""
     enc_id = urllib_quote(node_id)
     try:
-        data = figma_get_retry(f'/files/{file_key}/nodes?ids={enc_id}&depth=100', pat)
+        data = figma_get_retry(f'/files/{file_key}/nodes?ids={enc_id}&depth=100', pat, limiter=limiter)
         node = data.get('nodes', {}).get(node_id, {}).get('document') if data else None
         if not node:
             return None, None
@@ -264,7 +351,7 @@ def fetch_node_tree(file_key, node_id, pat):
         return None, None
 
 
-def fetch_figma_data(required_data, file_key, node_id, pat):
+def fetch_figma_data(required_data, file_key, node_id, pat, limiter=None):
     """Fetch only the declared data points from Figma API in parallel.
 
     Returns (dict[data_type -> value], tree_data).
@@ -276,28 +363,28 @@ def fetch_figma_data(required_data, file_key, node_id, pat):
     futures = {}
     with ThreadPoolExecutor(max_workers=3) as pool:
         if 'screenshot' in required_data:
-            futures['screenshot'] = pool.submit(fetch_screenshot, file_key, node_id, pat)
+            futures['screenshot'] = pool.submit(fetch_screenshot, file_key, node_id, pat, limiter=limiter)
         needs_tree = any(k in required_data for k in ('node_tree', 'text_nodes', 'annotations', 'prototype_flows'))
         if needs_tree:
-            futures['_tree'] = pool.submit(fetch_node_tree, file_key, node_id, pat)
+            futures['_tree'] = pool.submit(fetch_node_tree, file_key, node_id, pat, limiter=limiter)
         if 'dev_resources' in required_data:
             futures['dev_resources'] = pool.submit(
-                figma_get_retry, f'/files/{file_key}/dev_resources?node_ids={enc_id}', pat
+                figma_get_retry, f'/files/{file_key}/dev_resources?node_ids={enc_id}', pat, limiter=limiter
             )
         if 'variables_local' in required_data:
             futures['variables_local'] = pool.submit(
-                figma_get_retry, f'/files/{file_key}/variables/local', pat
+                figma_get_retry, f'/files/{file_key}/variables/local', pat, limiter=limiter
             )
         if 'variables_published' in required_data:
             futures['variables_published'] = pool.submit(
-                figma_get_retry, f'/files/{file_key}/variables/published', pat
+                figma_get_retry, f'/files/{file_key}/variables/published', pat, limiter=limiter
             )
         if 'styles' in required_data:
-            futures['styles'] = pool.submit(figma_get_retry, f'/files/{file_key}/styles', pat)
+            futures['styles'] = pool.submit(figma_get_retry, f'/files/{file_key}/styles', pat, limiter=limiter)
         if 'components' in required_data:
-            futures['components'] = pool.submit(figma_get_retry, f'/files/{file_key}/components', pat)
+            futures['components'] = pool.submit(figma_get_retry, f'/files/{file_key}/components', pat, limiter=limiter)
         if 'file_structure' in required_data:
-            futures['file_structure'] = pool.submit(figma_get_retry, f'/files/{file_key}?depth=2', pat)
+            futures['file_structure'] = pool.submit(figma_get_retry, f'/files/{file_key}?depth=2', pat, limiter=limiter)
 
         for key, future in futures.items():
             try:
@@ -350,8 +437,9 @@ class FigmaCommentRepository:
 class FigmaDesignDataRepository:
     """DesignDataRepository implementation backed by the Figma REST API."""
 
-    def __init__(self, pat: str):
+    def __init__(self, pat: str, limiter: 'FigmaRateLimiter | None' = None):
         self._pat = pat
+        self._limiter = limiter
 
     def fetch(self, required_data: list, file_key: str, node_id: str) -> tuple:
-        return fetch_figma_data(required_data, file_key, node_id, self._pat)
+        return fetch_figma_data(required_data, file_key, node_id, self._pat, limiter=self._limiter)

--- a/server.py
+++ b/server.py
@@ -33,6 +33,8 @@ Environment variables:
   FIGWATCH_LOG_FORMAT         Log format: text (default) or json
   FIGWATCH_SKILLS_DIR         Path to custom-skills directory (default: ./custom-skills)
   FIGWATCH_SKIP_TOKEN_CHECK   Skip Figma token validation at startup (for CI)
+  FIGWATCH_FIGMA_PLAN           Figma plan: starter, professional, organization, enterprise (default: professional)
+  FIGWATCH_FIGMA_SEAT           Figma seat type: dev, view (default: dev; ignored for starter)
 
   Observability (optional):
   OTEL_EXPORTER_OTLP_ENDPOINT   OTel collector endpoint (metrics disabled if unset)
@@ -67,8 +69,8 @@ from figwatch.metrics import (
 )
 from figwatch.providers.ai import CLAUDE_API_MODELS, GEMINI_MODELS
 from figwatch.providers.figma import (
-    FigmaCommentRepository, FigmaDesignDataRepository, FigmaTokenExpired,
-    figma_get_retry, validate_token,
+    FigmaCommentRepository, FigmaDesignDataRepository, FigmaRateLimiter,
+    FigmaTokenExpired, figma_get_retry, validate_token,
 )
 from figwatch.queue_stats import InstrumentedQueue, QueuedItem
 from figwatch.services import AuditConfig, AuditService
@@ -101,7 +103,7 @@ def _parse_file_keys(files_str):
     return keys
 
 
-def _resolve_node_id(comment, file_key, pat, comment_id=None):
+def _resolve_node_id(comment, file_key, pat, comment_id=None, limiter=None):
     """Return node_id for a comment, fetching the full comment from REST API if needed."""
     node_id = (comment.get('client_meta') or {}).get('node_id')
     if node_id:
@@ -113,7 +115,7 @@ def _resolve_node_id(comment, file_key, pat, comment_id=None):
         return None
 
     try:
-        data = figma_get_retry(f'/files/{file_key}/comments', pat)
+        data = figma_get_retry(f'/files/{file_key}/comments', pat, limiter=limiter)
         for c in (data or {}).get('comments', []):
             if str(c.get('id')) == str(lookup_id):
                 return (c.get('client_meta') or {}).get('node_id')
@@ -122,7 +124,8 @@ def _resolve_node_id(comment, file_key, pat, comment_id=None):
     return None
 
 
-def _build_audit(payload, comment_id, pat, allowed_file_keys, trigger_config, audit_id):
+def _build_audit(payload, comment_id, pat, allowed_file_keys, trigger_config, audit_id,
+                 limiter=None):
     """Parse a FILE_COMMENT payload into an Audit, or return (None, reason)."""
     file_key = payload.get('file_key')
     if allowed_file_keys and file_key not in allowed_file_keys:
@@ -137,7 +140,7 @@ def _build_audit(payload, comment_id, pat, allowed_file_keys, trigger_config, au
 
     parent_id = comment.get('parent_id') or ''
 
-    node_id = _resolve_node_id(comment, file_key, pat, comment_id=comment_id)
+    node_id = _resolve_node_id(comment, file_key, pat, comment_id=comment_id, limiter=limiter)
     if not node_id:
         return None, 'no node_id'
 
@@ -299,7 +302,7 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event,
 def _make_handler(pat, passcode, allowed_file_keys,
                   trigger_config, processed_ids, processed_lock, work_queue,
                   ack_updater: AckUpdater,
-                  audit_service: AuditService):
+                  audit_service: AuditService, limiter=None):
     class WebhookHandler(BaseHTTPRequestHandler):
         def do_GET(self):
             if self.path == '/health':
@@ -361,7 +364,7 @@ def _make_handler(pat, passcode, allowed_file_keys,
             audit_id = new_audit_id()
             audit, reason = _build_audit(
                 payload, comment_id, pat, allowed_file_keys,
-                trigger_config, audit_id,
+                trigger_config, audit_id, limiter=limiter,
             )
 
             if audit is None:
@@ -521,6 +524,22 @@ def main():
                      extra={'value': anthropic_rpm, 'min': 0})
         sys.exit(1)
 
+    figma_plan = os.environ.get('FIGWATCH_FIGMA_PLAN', 'professional').strip().lower()
+    valid_plans = ('starter', 'professional', 'organization', 'enterprise')
+    if figma_plan not in valid_plans:
+        logger.error('invalid FIGWATCH_FIGMA_PLAN',
+                     extra={'value': figma_plan, 'valid': valid_plans})
+        sys.exit(1)
+
+    figma_seat = os.environ.get('FIGWATCH_FIGMA_SEAT', 'dev').strip().lower()
+    valid_seats = ('dev', 'view')
+    if figma_seat not in valid_seats:
+        logger.error('invalid FIGWATCH_FIGMA_SEAT',
+                     extra={'value': figma_seat, 'valid': valid_seats})
+        sys.exit(1)
+
+    figma_limiter = FigmaRateLimiter(plan=figma_plan, seat=figma_seat)
+
     skills_dir = os.environ.get('FIGWATCH_SKILLS_DIR', '').strip() or None
     if skills_dir and not os.path.isdir(skills_dir):
         logger.error('FIGWATCH_SKILLS_DIR does not exist or is not a directory',
@@ -534,7 +553,7 @@ def main():
 
     # Construct repositories and application service
     comment_repo = FigmaCommentRepository(pat)
-    design_repo = FigmaDesignDataRepository(pat)
+    design_repo = FigmaDesignDataRepository(pat, limiter=figma_limiter)
     audit_config = AuditConfig(
         model=model, claude_path=claude_path,
         reply_lang='en', locale=locale,
@@ -577,7 +596,7 @@ def main():
         pat, passcode, allowed_file_keys,
         trigger_config, processed_ids, processed_lock, work_queue,
         ack_updater,
-        audit_service,
+        audit_service, limiter=figma_limiter,
     )
     server = HTTPServer(('', port), handler)
 

--- a/tests/test_figma_rate_limit.py
+++ b/tests/test_figma_rate_limit.py
@@ -1,0 +1,97 @@
+"""Tests for Figma tiered rate limiting."""
+
+import pytest
+
+from figwatch.providers.figma import (
+    TIER_1, TIER_2, TIER_3,
+    FigmaRateLimiter, endpoint_tier,
+)
+
+
+class TestEndpointTier:
+    """Verify endpoint-to-tier mapping matches Figma docs."""
+
+    # Tier 1: full file, nodes, image renders
+    @pytest.mark.parametrize('path', [
+        '/files/abc123?depth=2',
+        '/files/abc123',
+        '/files/abc123/nodes?ids=1%3A2&depth=100',
+        '/images/abc123?ids=1%3A2&scale=1&format=png',
+    ])
+    def test_tier_1(self, path):
+        assert endpoint_tier(path) == TIER_1
+
+    # Tier 2: comments, dev_resources, variables, projects
+    @pytest.mark.parametrize('path', [
+        '/files/abc123/comments',
+        '/files/abc123/dev_resources?node_ids=1%3A2',
+        '/files/abc123/variables/local',
+        '/files/abc123/variables/published',
+        '/teams/12345/projects',
+        '/projects/67890/files',
+    ])
+    def test_tier_2(self, path):
+        assert endpoint_tier(path) == TIER_2
+
+    # Tier 3: styles, components, metadata
+    @pytest.mark.parametrize('path', [
+        '/files/abc123/styles',
+        '/files/abc123/components',
+        '/files/abc123/component_sets',
+        '/teams/12345/components',
+        '/files/abc123/meta',
+    ])
+    def test_tier_3(self, path):
+        assert endpoint_tier(path) == TIER_3
+
+    def test_unknown_defaults_to_tier_2(self):
+        assert endpoint_tier('/some/unknown/endpoint') == TIER_2
+
+
+class TestFigmaRateLimiter:
+    """Verify limiter routes to correct tier bucket."""
+
+    def test_valid_plans(self):
+        FigmaRateLimiter(plan='starter')
+        FigmaRateLimiter(plan='professional', seat='dev')
+        FigmaRateLimiter(plan='professional', seat='view')
+        FigmaRateLimiter(plan='organization', seat='dev')
+        FigmaRateLimiter(plan='enterprise', seat='dev')
+
+    def test_invalid_plan_raises(self):
+        with pytest.raises(ValueError):
+            FigmaRateLimiter(plan='free', seat='dev')
+
+    def test_starter_ignores_seat(self):
+        # Starter has no seat distinction — should work without seat param
+        limiter = FigmaRateLimiter(plan='starter')
+        assert limiter._buckets[TIER_1] is not None
+
+    def test_acquire_routes_to_correct_bucket(self):
+        limiter = FigmaRateLimiter(plan='professional', seat='dev')
+        # All buckets start full — acquire should succeed immediately
+        limiter.acquire('/images/abc?ids=1%3A2&scale=1&format=png')  # Tier 1
+        limiter.acquire('/files/abc/comments')  # Tier 2
+        limiter.acquire('/files/abc/styles')  # Tier 3
+
+    def test_professional_dev_capacities(self):
+        limiter = FigmaRateLimiter(plan='professional', seat='dev')
+        assert limiter._buckets[TIER_1]._capacity == 10
+        assert limiter._buckets[TIER_2]._capacity == 25
+        assert limiter._buckets[TIER_3]._capacity == 50
+
+    def test_organization_dev_capacities(self):
+        limiter = FigmaRateLimiter(plan='organization', seat='dev')
+        assert limiter._buckets[TIER_1]._capacity == 15
+        assert limiter._buckets[TIER_2]._capacity == 50
+        assert limiter._buckets[TIER_3]._capacity == 100
+
+    def test_backoff_drains_correct_tier(self):
+        limiter = FigmaRateLimiter(plan='professional', seat='dev')
+        # Tier 1 bucket starts full (10 tokens)
+        bucket = limiter._buckets[TIER_1]
+        assert bucket._tokens == 10.0
+
+        # Backoff for 5 seconds should drain tokens negative
+        limiter.backoff('/images/abc?ids=1%3A2', 5.0)
+        assert bucket._tokens < 0

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -79,4 +79,4 @@ def test_design_data_repo_delegates(mock_fetch):
     data, tree = repo.fetch(['screenshot'], 'file-1', '2:3')
     assert data == {'screenshot': '/tmp/s.png'}
     assert tree == {'name': 'Frame'}
-    mock_fetch.assert_called_once_with(['screenshot'], 'file-1', '2:3', 'test-pat')
+    mock_fetch.assert_called_once_with(['screenshot'], 'file-1', '2:3', 'test-pat', limiter=None)

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -143,6 +143,23 @@ def test_anthropic_rpm_zero_accepted():
     _run_main(_env(FIGWATCH_ANTHROPIC_RPM='0'))
 
 
+# ── FIGWATCH_FIGMA_PLAN / FIGWATCH_FIGMA_SEAT ──────────────────────
+
+
+def test_figma_plan_invalid_exits():
+    with pytest.raises(SystemExit):
+        _run_main(_env(FIGWATCH_FIGMA_PLAN='invalid'))
+
+
+def test_figma_seat_invalid_exits():
+    with pytest.raises(SystemExit):
+        _run_main(_env(FIGWATCH_FIGMA_SEAT='admin'))
+
+
+def test_figma_plan_valid():
+    _run_main(_env(FIGWATCH_FIGMA_PLAN='organization', FIGWATCH_FIGMA_SEAT='dev'))
+
+
 # ── FIGMA_PAT token validation at startup ───────────────────────────
 
 


### PR DESCRIPTION
## Summary

Closes #33.

- Adds `FigmaRateLimiter` with 3 independent `TokenBucket`s matching Figma's tiered rate limit model (Tier 1/2/3)
- Endpoint-to-tier mapping based on [Figma docs](https://developers.figma.com/docs/rest-api/rate-limits/) — file/nodes/images = Tier 1, comments/variables/dev_resources/projects = Tier 2, styles/components = Tier 3
- Configured via `FIGWATCH_FIGMA_PLAN` (starter/professional/organization/enterprise) and `FIGWATCH_FIGMA_SEAT` (dev/view) with RPM values derived from Figma's published table
- On 429, drains the tier bucket using `Retry-After` header so all threads in that tier back off
- Threaded through `figma_get_retry`, `fetch_figma_data`, `fetch_screenshot`, `fetch_node_tree`, and `FigmaDesignDataRepository`

## Test plan

- [x] 23 new tests for `endpoint_tier()` and `FigmaRateLimiter` (tier routing, capacities, backoff, plan validation)
- [x] 3 new server config tests for `FIGWATCH_FIGMA_PLAN` / `FIGWATCH_FIGMA_SEAT` fail-fast validation
- [x] All 242 existing + new tests pass
- [x] Manual: deploy with `FIGWATCH_FIGMA_PLAN=professional`, trigger audit burst, verify no unexpected 429s