### PR TITLE
feat: add OpenTelemetry distributed tracing

### DIFF
--- a/figwatch/__init__.py
+++ b/figwatch/__init__.py
@@ -1,3 +1,3 @@
 """FigWatch — AI-powered Figma design auditor."""
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"

--- a/figwatch/logging_config.py
+++ b/figwatch/logging_config.py
@@ -94,7 +94,7 @@ class TextFormatter(logging.Formatter):
         ctx_parts = []
         trace_id = getattr(record, 'trace_id', '')
         if trace_id:
-            ctx_parts.append(f'trace={trace_id[-8:]}')
+            ctx_parts.append(f'trace={trace_id[:8]}')
         for key in _TEXT_CONTEXT_KEYS:
             if key in ctx:
                 ctx_parts.append(f'{key}={ctx[key]}')

--- a/figwatch/logging_config.py
+++ b/figwatch/logging_config.py
@@ -45,6 +45,20 @@ class ContextFilter(logging.Filter):
         for key, value in ctx.items():
             if not hasattr(record, key):
                 setattr(record, key, value)
+
+        # Inject OTel trace/span IDs when a span is active.
+        record.trace_id = ''
+        record.span_id = ''
+        try:
+            from opentelemetry import trace
+            span = trace.get_current_span()
+            ctx = span.get_span_context()
+            if ctx and ctx.trace_id:
+                record.trace_id = format(ctx.trace_id, '032x')
+                record.span_id = format(ctx.span_id, '016x')
+        except ImportError:
+            pass
+
         return True
 
 
@@ -78,6 +92,9 @@ class TextFormatter(logging.Formatter):
         # Build inline key=value context prefix
         ctx = getattr(record, 'audit_context', {}) or {}
         ctx_parts = []
+        trace_id = getattr(record, 'trace_id', '')
+        if trace_id:
+            ctx_parts.append(f'trace={trace_id[:8]}')
         for key in _TEXT_CONTEXT_KEYS:
             if key in ctx:
                 ctx_parts.append(f'{key}={ctx[key]}')
@@ -87,7 +104,7 @@ class TextFormatter(logging.Formatter):
         # standard LogRecord attrs and our own context dict.
         extra_parts = []
         for key, value in record.__dict__.items():
-            if key in _STD_RECORD_ATTRS or key == 'audit_context':
+            if key in _STD_RECORD_ATTRS or key in ('audit_context', 'trace_id', 'span_id'):
                 continue
             if key in ctx:
                 continue
@@ -122,8 +139,14 @@ class JsonFormatter(logging.Formatter):
         ctx = getattr(record, 'audit_context', {}) or {}
         payload.update(ctx)
 
+        trace_id = getattr(record, 'trace_id', '')
+        span_id = getattr(record, 'span_id', '')
+        if trace_id:
+            payload['trace_id'] = trace_id
+            payload['span_id'] = span_id
+
         for key, value in record.__dict__.items():
-            if key in _STD_RECORD_ATTRS or key == 'audit_context':
+            if key in _STD_RECORD_ATTRS or key in ('audit_context', 'trace_id', 'span_id'):
                 continue
             if key in payload:
                 continue

--- a/figwatch/logging_config.py
+++ b/figwatch/logging_config.py
@@ -94,7 +94,7 @@ class TextFormatter(logging.Formatter):
         ctx_parts = []
         trace_id = getattr(record, 'trace_id', '')
         if trace_id:
-            ctx_parts.append(f'trace={trace_id[:8]}')
+            ctx_parts.append(f'trace={trace_id}')
         for key in _TEXT_CONTEXT_KEYS:
             if key in ctx:
                 ctx_parts.append(f'{key}={ctx[key]}')

--- a/figwatch/logging_config.py
+++ b/figwatch/logging_config.py
@@ -94,7 +94,7 @@ class TextFormatter(logging.Formatter):
         ctx_parts = []
         trace_id = getattr(record, 'trace_id', '')
         if trace_id:
-            ctx_parts.append(f'trace={trace_id[:8]}')
+            ctx_parts.append(f'trace={trace_id[-8:]}')
         for key in _TEXT_CONTEXT_KEYS:
             if key in ctx:
                 ctx_parts.append(f'{key}={ctx[key]}')

--- a/figwatch/providers/figma.py
+++ b/figwatch/providers/figma.py
@@ -10,9 +10,8 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from concurrent.futures import ThreadPoolExecutor
-
 from figwatch.providers.ai.rate_limit import TokenBucket
+from figwatch.tracing import TracedThreadPoolExecutor, get_tracer
 
 logger = logging.getLogger(__name__)
 
@@ -178,44 +177,57 @@ def figma_get_retry(path, pat, retries=1, timeout=15, limiter=None):
     If *limiter* is provided, acquires from the appropriate tier bucket before
     making the request.
     """
-    if limiter:
-        limiter.acquire(path)
-    for attempt in range(retries + 1):
-        try:
-            req = urllib.request.Request(
-                f'{FIGMA_API}{path}',
-                headers={'X-Figma-Token': pat},
-            )
-            with urllib.request.urlopen(req, timeout=timeout) as r:
-                return json.loads(r.read())
-        except urllib.error.HTTPError as e:
-            _check_token_expired(e)
-            if e.code == 429 and attempt < retries:
-                try:
-                    wait = int(e.headers.get('Retry-After', '0') or 0)
-                except Exception:
-                    wait = 0
-                wait = max(wait, 2)
-                if limiter:
-                    limiter.backoff(path, wait)
-                logger.warning(
-                    'figma 429 — retrying',
-                    extra={'path': path, 'retry_in_seconds': wait},
+    tracer = get_tracer()
+    with tracer.start_as_current_span('figma.api_call', attributes={
+        'figma.endpoint': path,
+        'figma.rate_limit_tier': endpoint_tier(path),
+    }) as span:
+        if limiter:
+            limiter.acquire(path)
+        for attempt in range(retries + 1):
+            try:
+                req = urllib.request.Request(
+                    f'{FIGMA_API}{path}',
+                    headers={'X-Figma-Token': pat},
                 )
-                time.sleep(wait)
-                continue
-            logger.warning('figma API error',
-                           extra={'path': path, 'status': e.code})
-            return None
-        except (socket.timeout, TimeoutError):
-            logger.warning('figma API timeout',
-                           extra={'path': path, 'timeout': timeout})
-            raise
-        except Exception as e:
-            logger.warning('figma API call failed',
-                           extra={'path': path, 'error': str(e)})
-            return None
-    return None
+                with urllib.request.urlopen(req, timeout=timeout) as r:
+                    span.set_attribute('figma.status_code', r.status)
+                    span.set_attribute('figma.retry_count', attempt)
+                    return json.loads(r.read())
+            except urllib.error.HTTPError as e:
+                span.set_attribute('figma.status_code', e.code)
+                span.set_attribute('figma.retry_count', attempt)
+                _check_token_expired(e)
+                if e.code == 429 and attempt < retries:
+                    try:
+                        wait = int(e.headers.get('Retry-After', '0') or 0)
+                    except Exception:
+                        wait = 0
+                    wait = max(wait, 2)
+                    if limiter:
+                        limiter.backoff(path, wait)
+                    logger.warning(
+                        'figma 429 — retrying',
+                        extra={'path': path, 'retry_in_seconds': wait},
+                    )
+                    time.sleep(wait)
+                    continue
+                logger.warning('figma API error',
+                               extra={'path': path, 'status': e.code})
+                return None
+            except (socket.timeout, TimeoutError):
+                span.set_attribute('figma.retry_count', attempt)
+                span.record_exception(socket.timeout('timeout'))
+                logger.warning('figma API timeout',
+                               extra={'path': path, 'timeout': timeout})
+                raise
+            except Exception as e:
+                span.set_attribute('figma.retry_count', attempt)
+                span.record_exception(e)
+                logger.warning('figma API call failed',
+                               extra={'path': path, 'error': str(e)})
+                return None
+        return None
 
 
 # ── Node data extraction ──────────────────────────────────────────────
@@ -293,62 +305,72 @@ def fetch_screenshot(file_key, node_id, pat, limiter=None):
     Timeouts abort immediately — retrying at smaller scales won't help when
     Figma is slow to render (see #37).
     """
-    enc_id = urllib_quote(node_id)
-    attempts = [('png', 1), ('png', 0.5), ('jpg', 1), ('jpg', 0.5), ('jpg', 0.25)]
+    tracer = get_tracer()
+    with tracer.start_as_current_span('figma.screenshot', attributes={
+        'figma.file_key': file_key,
+        'figma.node_id': node_id,
+    }):
+        enc_id = urllib_quote(node_id)
+        attempts = [('png', 1), ('png', 0.5), ('jpg', 1), ('jpg', 0.5), ('jpg', 0.25)]
 
-    for fmt, scale in attempts:
-        out_path = os.path.join(
-            tempfile.gettempdir(),
-            f'figwatch-screenshot-{node_id.replace(":", "-")}.{fmt}',
-        )
-        try:
-            data = figma_get_retry(
-                f'/images/{file_key}?ids={enc_id}&scale={scale}&format={fmt}',
-                pat,
-                timeout=45,
-                limiter=limiter,
+        for fmt, scale in attempts:
+            out_path = os.path.join(
+                tempfile.gettempdir(),
+                f'figwatch-screenshot-{node_id.replace(":", "-")}.{fmt}',
             )
-            if not data or data.get('err') or data.get('status') == 400:
+            try:
+                data = figma_get_retry(
+                    f'/images/{file_key}?ids={enc_id}&scale={scale}&format={fmt}',
+                    pat,
+                    timeout=45,
+                    limiter=limiter,
+                )
+                if not data or data.get('err') or data.get('status') == 400:
+                    continue
+                url = (data.get('images') or {}).get(node_id)
+                if not url:
+                    continue
+                with urllib.request.urlopen(url, timeout=30) as r:
+                    img_bytes = r.read()
+                if len(img_bytes) > _MAX_IMAGE_BYTES:
+                    continue
+                with open(out_path, 'wb') as f:
+                    f.write(img_bytes)
+                return out_path
+            except (socket.timeout, TimeoutError):
+                logger.warning(
+                    'screenshot render timed out — aborting fallback chain',
+                    extra={'file_key': file_key, 'node_id': node_id,
+                           'format': fmt, 'scale': scale},
+                )
+                return None
+            except Exception:
                 continue
-            url = (data.get('images') or {}).get(node_id)
-            if not url:
-                continue
-            with urllib.request.urlopen(url, timeout=30) as r:
-                img_bytes = r.read()
-            if len(img_bytes) > _MAX_IMAGE_BYTES:
-                continue
-            with open(out_path, 'wb') as f:
-                f.write(img_bytes)
-            return out_path
-        except (socket.timeout, TimeoutError):
-            logger.warning(
-                'screenshot render timed out — aborting fallback chain',
-                extra={'file_key': file_key, 'node_id': node_id,
-                       'format': fmt, 'scale': scale},
-            )
-            return None
-        except Exception:
-            continue
-    return None
+        return None
 
 
 def fetch_node_tree(file_key, node_id, pat, limiter=None):
     """Fetch the full node tree for a Figma node. Returns (file_path, parsed_data) or (None, None)."""
-    enc_id = urllib_quote(node_id)
-    try:
-        data = figma_get_retry(f'/files/{file_key}/nodes?ids={enc_id}&depth=100', pat, limiter=limiter)
-        node = data.get('nodes', {}).get(node_id, {}).get('document') if data else None
-        if not node:
+    tracer = get_tracer()
+    with tracer.start_as_current_span('figma.node_tree', attributes={
+        'figma.file_key': file_key,
+        'figma.node_id': node_id,
+    }):
+        enc_id = urllib_quote(node_id)
+        try:
+            data = figma_get_retry(f'/files/{file_key}/nodes?ids={enc_id}&depth=100', pat, limiter=limiter)
+            node = data.get('nodes', {}).get(node_id, {}).get('document') if data else None
+            if not node:
+                return None, None
+            out_path = os.path.join(
+                tempfile.gettempdir(),
+                f'figwatch-tree-{node_id.replace(":", "-")}.json',
+            )
+            with open(out_path, 'w', encoding='utf-8') as f:
+                json.dump(node, f, indent=2)
+            return out_path, node
+        except Exception:
             return None, None
-        out_path = os.path.join(
-            tempfile.gettempdir(),
-            f'figwatch-tree-{node_id.replace(":", "-")}.json',
-        )
-        with open(out_path, 'w', encoding='utf-8') as f:
-            json.dump(node, f, indent=2)
-        return out_path, node
-    except Exception:
-        return None, None
 
 
 def fetch_figma_data(required_data, file_key, node_id, pat, limiter=None):
@@ -356,56 +378,61 @@ def fetch_figma_data(required_data, file_key, node_id, pat, limiter=None):
 
     Returns (dict[data_type -> value], tree_data).
     """
-    result = {}
-    enc_id = urllib_quote(node_id)
-    tree_data = None
+    tracer = get_tracer()
+    with tracer.start_as_current_span('figma.fetch_data', attributes={
+        'figma.file_key': file_key,
+        'figma.node_id': node_id,
+    }):
+        result = {}
+        enc_id = urllib_quote(node_id)
+        tree_data = None
 
-    futures = {}
-    with ThreadPoolExecutor(max_workers=3) as pool:
-        if 'screenshot' in required_data:
-            futures['screenshot'] = pool.submit(fetch_screenshot, file_key, node_id, pat, limiter=limiter)
-        needs_tree = any(k in required_data for k in ('node_tree', 'text_nodes', 'annotations', 'prototype_flows'))
-        if needs_tree:
-            futures['_tree'] = pool.submit(fetch_node_tree, file_key, node_id, pat, limiter=limiter)
-        if 'dev_resources' in required_data:
-            futures['dev_resources'] = pool.submit(
-                figma_get_retry, f'/files/{file_key}/dev_resources?node_ids={enc_id}', pat, limiter=limiter
-            )
-        if 'variables_local' in required_data:
-            futures['variables_local'] = pool.submit(
-                figma_get_retry, f'/files/{file_key}/variables/local', pat, limiter=limiter
-            )
-        if 'variables_published' in required_data:
-            futures['variables_published'] = pool.submit(
-                figma_get_retry, f'/files/{file_key}/variables/published', pat, limiter=limiter
-            )
-        if 'styles' in required_data:
-            futures['styles'] = pool.submit(figma_get_retry, f'/files/{file_key}/styles', pat, limiter=limiter)
-        if 'components' in required_data:
-            futures['components'] = pool.submit(figma_get_retry, f'/files/{file_key}/components', pat, limiter=limiter)
-        if 'file_structure' in required_data:
-            futures['file_structure'] = pool.submit(figma_get_retry, f'/files/{file_key}?depth=2', pat, limiter=limiter)
+        futures = {}
+        with TracedThreadPoolExecutor(max_workers=3) as pool:
+            if 'screenshot' in required_data:
+                futures['screenshot'] = pool.submit(fetch_screenshot, file_key, node_id, pat, limiter=limiter)
+            needs_tree = any(k in required_data for k in ('node_tree', 'text_nodes', 'annotations', 'prototype_flows'))
+            if needs_tree:
+                futures['_tree'] = pool.submit(fetch_node_tree, file_key, node_id, pat, limiter=limiter)
+            if 'dev_resources' in required_data:
+                futures['dev_resources'] = pool.submit(
+                    figma_get_retry, f'/files/{file_key}/dev_resources?node_ids={enc_id}', pat, limiter=limiter
+                )
+            if 'variables_local' in required_data:
+                futures['variables_local'] = pool.submit(
+                    figma_get_retry, f'/files/{file_key}/variables/local', pat, limiter=limiter
+                )
+            if 'variables_published' in required_data:
+                futures['variables_published'] = pool.submit(
+                    figma_get_retry, f'/files/{file_key}/variables/published', pat, limiter=limiter
+                )
+            if 'styles' in required_data:
+                futures['styles'] = pool.submit(figma_get_retry, f'/files/{file_key}/styles', pat, limiter=limiter)
+            if 'components' in required_data:
+                futures['components'] = pool.submit(figma_get_retry, f'/files/{file_key}/components', pat, limiter=limiter)
+            if 'file_structure' in required_data:
+                futures['file_structure'] = pool.submit(figma_get_retry, f'/files/{file_key}?depth=2', pat, limiter=limiter)
 
-        for key, future in futures.items():
-            try:
-                result[key] = future.result()
-            except Exception:
-                result[key] = None
+            for key, future in futures.items():
+                try:
+                    result[key] = future.result()
+                except Exception:
+                    result[key] = None
 
-    tree_result = result.pop('_tree', None)
-    if tree_result:
-        tree_path, tree_data = tree_result
-        result['node_tree'] = tree_path
+        tree_result = result.pop('_tree', None)
+        if tree_result:
+            tree_path, tree_data = tree_result
+            result['node_tree'] = tree_path
 
-    if tree_data:
-        if 'text_nodes' in required_data:
-            result['text_nodes'] = extract_text_from_node(tree_data)
-        if 'prototype_flows' in required_data:
-            result['prototype_flows'] = _extract_prototype_flows(tree_data)
-        if 'annotations' in required_data:
-            result['annotations'] = _extract_annotations(tree_data)
+        if tree_data:
+            if 'text_nodes' in required_data:
+                result['text_nodes'] = extract_text_from_node(tree_data)
+            if 'prototype_flows' in required_data:
+                result['prototype_flows'] = _extract_prototype_flows(tree_data)
+            if 'annotations' in required_data:
+                result['annotations'] = _extract_annotations(tree_data)
 
-    return result, tree_data
+        return result, tree_data
 
 
 # ── Repository implementations ───────────────────────────────────────

--- a/figwatch/queue_stats.py
+++ b/figwatch/queue_stats.py
@@ -24,6 +24,7 @@ class QueuedItem:
     enqueued_at: float = field(default_factory=time.monotonic)
     attempt: int = 1
     waited_seconds: float = 0.0
+    trace_context: dict = field(default_factory=dict)
 
 
 @dataclass

--- a/figwatch/queue_stats.py
+++ b/figwatch/queue_stats.py
@@ -24,7 +24,7 @@ class QueuedItem:
     enqueued_at: float = field(default_factory=time.monotonic)
     attempt: int = 1
     waited_seconds: float = 0.0
-    trace_context: dict = field(default_factory=dict)
+    trace_context: Any = None
 
 
 @dataclass

--- a/figwatch/services.py
+++ b/figwatch/services.py
@@ -7,6 +7,7 @@ from typing import Optional
 from figwatch.domain import Audit, AuditCompleted, AuditFailed, AuditResult
 from figwatch.ports import CommentRepository, DesignDataRepository
 from figwatch.processor import clean_reply
+from figwatch.tracing import get_tracer
 
 logger = logging.getLogger(__name__)
 
@@ -67,11 +68,15 @@ class AuditService:
         return self.post_ack(audit, message)
 
     def post_reply(self, audit: Audit, message: str) -> None:
-        self._comments.post_reply(
-            audit.comment.file_key,
-            audit.reply_to_id,
-            message,
-        )
+        tracer = get_tracer()
+        with tracer.start_as_current_span('figma.post_reply', attributes={
+            'figma.file_key': audit.comment.file_key,
+        }):
+            self._comments.post_reply(
+                audit.comment.file_key,
+                audit.reply_to_id,
+                message,
+            )
 
     def execute(self, audit: Audit) -> str:
         """Run skill for an audit. Returns cleaned reply string.

--- a/figwatch/skills.py
+++ b/figwatch/skills.py
@@ -10,6 +10,7 @@ from figwatch.providers.ai import make_provider, GEMINI_MODELS, CLAUDE_API_MODEL
 from figwatch.providers.ai.gemini import GeminiProvider
 from figwatch.providers.ai.anthropic import AnthropicProvider
 from figwatch.providers.ai.claude_cli import ClaudeCLIProvider
+from figwatch.tracing import get_tracer
 
 logger = logging.getLogger(__name__)
 
@@ -186,9 +187,14 @@ def introspect_skill(skill_path, claude_path, model=None):
 
 
 def _get_introspection(skill_ref, skill_path, claude_path, model):
-    if skill_ref in _BUILTIN_INTROSPECTION:
-        return _BUILTIN_INTROSPECTION[skill_ref]
-    return introspect_skill(skill_path, claude_path, model)
+    tracer = get_tracer()
+    with tracer.start_as_current_span('skill.introspect', attributes={
+        'skill.name': skill_ref,
+        'skill.builtin': skill_ref in _BUILTIN_INTROSPECTION,
+    }):
+        if skill_ref in _BUILTIN_INTROSPECTION:
+            return _BUILTIN_INTROSPECTION[skill_ref]
+        return introspect_skill(skill_path, claude_path, model)
 
 
 # ── Prompt builder ────────────────────────────────────────────────────
@@ -333,8 +339,19 @@ def execute_skill(audit, *, config, design_repo):
         inline_files=provider.inline_files, config=config,
     )
 
+    tracer = get_tracer()
     try:
-        reply = provider.call(prompt, data.get('screenshot'))
+        with tracer.start_as_current_span('skill.execute', attributes={
+            'skill.name': skill_ref,
+            'skill.builtin': skill_ref.startswith('builtin:'),
+            'ai.provider': type(provider).__name__,
+            'ai.model': provider.model_id,
+        }) as span:
+            reply = provider.call(prompt, data.get('screenshot'))
+            if hasattr(provider, 'last_token_usage'):
+                usage = provider.last_token_usage
+                if usage:
+                    span.set_attribute('ai.tokens', usage)
         header = f'\U0001f5e3\ufe0f {trigger_kw} Audit \u2014 {frame_name}'
         return f'{header}\n\n{reply}\n\n\u2014 {provider.model_id}'
     finally:

--- a/figwatch/tracing.py
+++ b/figwatch/tracing.py
@@ -1,0 +1,106 @@
+"""OpenTelemetry tracing for FigWatch audit lifecycle.
+
+Initialises a TracerProvider with OTLP gRPC exporter when
+OTEL_EXPORTER_OTLP_ENDPOINT is set. Falls back to noop (zero overhead)
+when the endpoint is not configured.
+"""
+
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+logger = logging.getLogger(__name__)
+
+_tracer = None
+
+
+def init_tracing(service_name='figwatch'):
+    """Initialise OTel tracing. Safe to call unconditionally — noops if
+    OTEL_EXPORTER_OTLP_ENDPOINT is not set.
+    """
+    global _tracer
+
+    endpoint = os.environ.get('OTEL_EXPORTER_OTLP_ENDPOINT', '').strip()
+    if not endpoint:
+        logger.info('OTEL_EXPORTER_OTLP_ENDPOINT not set — tracing disabled')
+        return
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+            OTLPSpanExporter,
+        )
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    except ImportError:
+        logger.warning(
+            'opentelemetry packages not installed — tracing disabled. '
+            'Install with: pip install "figwatch[server]"'
+        )
+        return
+
+    resource = Resource.create({'service.name': service_name})
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(provider)
+
+    _tracer = trace.get_tracer('figwatch')
+    logger.info('OTel tracing initialised', extra={'endpoint': endpoint})
+
+
+def get_tracer():
+    """Return the initialised tracer, or a noop tracer if tracing is disabled."""
+    if _tracer:
+        return _tracer
+    try:
+        from opentelemetry import trace
+        return trace.get_tracer('figwatch')
+    except ImportError:
+        return _NoopTracer()
+
+
+class _NoopSpan:
+    """Minimal stand-in when opentelemetry is not installed."""
+
+    def set_attribute(self, key, value):
+        pass
+
+    def set_status(self, *args, **kwargs):
+        pass
+
+    def record_exception(self, exception):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+class _NoopTracer:
+    """Minimal stand-in when opentelemetry is not installed."""
+
+    def start_as_current_span(self, name, **kwargs):
+        return _NoopSpan()
+
+
+class TracedThreadPoolExecutor(ThreadPoolExecutor):
+    """ThreadPoolExecutor that propagates OTel context to worker threads."""
+
+    def submit(self, fn, /, *args, **kwargs):
+        try:
+            from opentelemetry import context
+            ctx = context.get_current()
+
+            def _wrapped():
+                token = context.attach(ctx)
+                try:
+                    return fn(*args, **kwargs)
+                finally:
+                    context.detach(token)
+
+            return super().submit(_wrapped)
+        except ImportError:
+            return super().submit(fn, *args, **kwargs)

--- a/server.py
+++ b/server.py
@@ -67,6 +67,7 @@ from figwatch.metrics import (
     init_metrics, record_queue_change, record_token_expired,
     record_webhook_received,
 )
+from figwatch.tracing import get_tracer, init_tracing
 from figwatch.providers.ai import CLAUDE_API_MODELS, GEMINI_MODELS
 from figwatch.providers.figma import (
     FigmaCommentRepository, FigmaDesignDataRepository, FigmaRateLimiter,
@@ -192,6 +193,16 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event,
         ack_id = queued.ack_id
         run_started_at = time.monotonic()
 
+        # Restore trace context propagated from the webhook handler thread.
+        otel_token = None
+        try:
+            from opentelemetry import context as otel_context
+            from opentelemetry.propagators.textmap import extract
+            ctx = extract(queued.trace_context)
+            otel_token = otel_context.attach(ctx)
+        except ImportError:
+            pass
+
         token = set_audit_context(
             audit=queued.audit_id,
             trigger=trigger_kw,
@@ -199,7 +210,14 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event,
             file=audit.comment.file_key,
             attempt=queued.attempt,
         )
+        tracer = get_tracer()
         try:
+          with tracer.start_as_current_span('audit', attributes={
+              'audit.id': queued.audit_id,
+              'audit.file_key': audit.comment.file_key,
+              'audit.node_id': audit.comment.node_id,
+              'audit.trigger': trigger_kw,
+          }) as span:
             record_queue_change(-1)
             stats = work_queue.stats()
             logger.info(
@@ -226,6 +244,7 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event,
                 except FigmaTokenExpired as err:
                     last_err = err
                     record_token_expired()
+                    span.record_exception(err)
                     logger.error(
                         'Figma token expired — skipping retries',
                         extra={'attempt': attempt + 1},
@@ -268,6 +287,11 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event,
                     },
                 )
             else:
+                try:
+                    from opentelemetry.trace import StatusCode
+                    span.set_status(StatusCode.ERROR, str(last_err))
+                except ImportError:
+                    pass
                 audit_service.delete_ack(audit, ack_id)
                 try:
                     audit_service.post_reply(
@@ -295,6 +319,12 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event,
         finally:
             work_queue.task_done()
             reset_audit_context(token)
+            if otel_token is not None:
+                try:
+                    from opentelemetry import context as otel_context
+                    otel_context.detach(otel_token)
+                except ImportError:
+                    pass
 
 
 # ── HTTP handler ───────────────────────────────────────────────────────
@@ -404,10 +434,18 @@ def _make_handler(pat, passcode, allowed_file_keys,
 
             ack_id = audit_service.post_ack(audit, queue_msg)
 
+            trace_ctx = {}
+            try:
+                from opentelemetry.propagators.textmap import inject
+                inject(trace_ctx)
+            except ImportError:
+                pass
+
             queued = QueuedItem(
                 audit=audit,
                 ack_id=ack_id,
                 audit_id=audit_id,
+                trace_context=trace_ctx,
             )
             work_queue.put(queued)
             record_queue_change(1)
@@ -547,6 +585,7 @@ def main():
         sys.exit(1)
 
     init_metrics()
+    init_tracing()
 
     trigger_config = load_trigger_config(skills_dir)
     triggers_str = ', '.join(t.get('trigger', '') for t in trigger_config)

--- a/server.py
+++ b/server.py
@@ -390,78 +390,80 @@ def _make_handler(pat, passcode, allowed_file_keys,
                     return
                 processed_ids.add(comment_id)
 
+            audit_id = new_audit_id()
+            audit, reason = _build_audit(
+                payload, comment_id, pat, allowed_file_keys,
+                trigger_config, audit_id, limiter=limiter,
+            )
+
+            if audit is None:
+                logger.debug('skip', extra={'reason': reason})
+                self._respond(200, reason)
+                return
+
+            save_processed(processed_ids)
+
+            trigger_kw = audit.trigger_match.trigger.keyword
+
+            # Temporarily set context so the ack post + enqueue log lines
+            # carry the new audit_id. Cleared on next request.
+            set_audit_context(
+                audit=audit_id,
+                trigger=trigger_kw,
+                node=audit.comment.node_id,
+                file=file_key,
+            )
+
+            logger.info(
+                '\U0001f4ac trigger matched',
+                extra={'user': audit.comment.user_handle},
+            )
+
             tracer = get_tracer()
             with tracer.start_as_current_span('webhook.receive', attributes={
                 'figma.file_key': file_key,
                 'figma.comment_id': str(comment_id),
+                'audit.id': audit_id,
+                'audit.trigger': trigger_kw,
             }):
-              audit_id = new_audit_id()
-              audit, reason = _build_audit(
-                  payload, comment_id, pat, allowed_file_keys,
-                  trigger_config, audit_id, limiter=limiter,
-              )
+                ahead = work_queue.depth
+                if ahead == 0:
+                    queue_msg = (
+                        f'\u23f3 {trigger_kw.lstrip("@")} audit queued '
+                        f'\u2014 starting shortly\u2026'
+                    )
+                else:
+                    queue_msg = (
+                        f'\u23f3 {trigger_kw.lstrip("@")} audit queued '
+                        f'({ahead} ahead of you)\u2026'
+                    )
 
-              if audit is None:
-                  logger.debug('skip', extra={'reason': reason})
-                  self._respond(200, reason)
-                  return
+                ack_id = audit_service.post_ack(audit, queue_msg)
 
-              save_processed(processed_ids)
+                trace_ctx = None
+                try:
+                    from opentelemetry import context as otel_context
+                    trace_ctx = otel_context.get_current()
+                except ImportError:
+                    pass
 
-              trigger_kw = audit.trigger_match.trigger.keyword
+                queued = QueuedItem(
+                    audit=audit,
+                    ack_id=ack_id,
+                    audit_id=audit_id,
+                    trace_context=trace_ctx,
+                )
+                work_queue.put(queued)
+                record_queue_change(1)
 
-              # Temporarily set context so the ack post + enqueue log lines
-              # carry the new audit_id. Cleared on next request.
-              set_audit_context(
-                  audit=audit_id,
-                  trigger=trigger_kw,
-                  node=audit.comment.node_id,
-                  file=file_key,
-              )
+                # Record initial displayed position so the updater only fires
+                # when the position actually changes.
+                ack_updater.track_initial(audit_id, position=ahead)
 
-              logger.info(
-                  '\U0001f4ac trigger matched',
-                  extra={'user': audit.comment.user_handle},
-              )
+                stats = work_queue.stats()
+                logger.info('queue.enqueued', extra={'depth': stats.depth})
 
-              ahead = work_queue.depth
-              if ahead == 0:
-                  queue_msg = (
-                      f'\u23f3 {trigger_kw.lstrip("@")} audit queued '
-                      f'\u2014 starting shortly\u2026'
-                  )
-              else:
-                  queue_msg = (
-                      f'\u23f3 {trigger_kw.lstrip("@")} audit queued '
-                      f'({ahead} ahead of you)\u2026'
-                  )
-
-              ack_id = audit_service.post_ack(audit, queue_msg)
-
-              trace_ctx = None
-              try:
-                  from opentelemetry import context as otel_context
-                  trace_ctx = otel_context.get_current()
-              except ImportError:
-                  pass
-
-              queued = QueuedItem(
-                  audit=audit,
-                  ack_id=ack_id,
-                  audit_id=audit_id,
-                  trace_context=trace_ctx,
-              )
-              work_queue.put(queued)
-              record_queue_change(1)
-
-              # Record initial displayed position so the updater only fires
-              # when the position actually changes.
-              ack_updater.track_initial(audit_id, position=ahead)
-
-              stats = work_queue.stats()
-              logger.info('queue.enqueued', extra={'depth': stats.depth})
-
-              self._respond(200, 'Queued')
+                self._respond(200, 'Queued')
 
         def _respond(self, code, message):
             body = message.encode()

--- a/server.py
+++ b/server.py
@@ -390,42 +390,40 @@ def _make_handler(pat, passcode, allowed_file_keys,
                     return
                 processed_ids.add(comment_id)
 
-            audit_id = new_audit_id()
-            audit, reason = _build_audit(
-                payload, comment_id, pat, allowed_file_keys,
-                trigger_config, audit_id, limiter=limiter,
-            )
-
-            if audit is None:
-                logger.debug('skip', extra={'reason': reason})
-                self._respond(200, reason)
-                return
-
-            save_processed(processed_ids)
-
-            trigger_kw = audit.trigger_match.trigger.keyword
-
-            # Temporarily set context so the ack post + enqueue log lines
-            # carry the new audit_id. Cleared on next request.
-            set_audit_context(
-                audit=audit_id,
-                trigger=trigger_kw,
-                node=audit.comment.node_id,
-                file=file_key,
-            )
-
-            logger.info(
-                '\U0001f4ac trigger matched',
-                extra={'user': audit.comment.user_handle},
-            )
-
             tracer = get_tracer()
             with tracer.start_as_current_span('webhook.receive', attributes={
                 'figma.file_key': file_key,
                 'figma.comment_id': str(comment_id),
-                'audit.id': audit_id,
-                'audit.trigger': trigger_kw,
             }):
+                audit_id = new_audit_id()
+                audit, reason = _build_audit(
+                    payload, comment_id, pat, allowed_file_keys,
+                    trigger_config, audit_id, limiter=limiter,
+                )
+
+                if audit is None:
+                    logger.debug('skip', extra={'reason': reason})
+                    self._respond(200, reason)
+                    return
+
+                save_processed(processed_ids)
+
+                trigger_kw = audit.trigger_match.trigger.keyword
+
+                # Temporarily set context so the ack post + enqueue log lines
+                # carry the new audit_id. Cleared on next request.
+                set_audit_context(
+                    audit=audit_id,
+                    trigger=trigger_kw,
+                    node=audit.comment.node_id,
+                    file=file_key,
+                )
+
+                logger.info(
+                    '\U0001f4ac trigger matched',
+                    extra={'user': audit.comment.user_handle},
+                )
+
                 ahead = work_queue.depth
                 if ahead == 0:
                     queue_msg = (

--- a/server.py
+++ b/server.py
@@ -197,9 +197,8 @@ def _worker_loop(work_queue: InstrumentedQueue, stop_event,
         otel_token = None
         try:
             from opentelemetry import context as otel_context
-            from opentelemetry.propagators.textmap import extract
-            ctx = extract(queued.trace_context)
-            otel_token = otel_context.attach(ctx)
+            if queued.trace_context is not None:
+                otel_token = otel_context.attach(queued.trace_context)
         except ImportError:
             pass
 
@@ -439,10 +438,10 @@ def _make_handler(pat, passcode, allowed_file_keys,
 
               ack_id = audit_service.post_ack(audit, queue_msg)
 
-              trace_ctx = {}
+              trace_ctx = None
               try:
-                  from opentelemetry.propagators.textmap import inject
-                  inject(trace_ctx)
+                  from opentelemetry import context as otel_context
+                  trace_ctx = otel_context.get_current()
               except ImportError:
                   pass
 

--- a/server.py
+++ b/server.py
@@ -391,73 +391,78 @@ def _make_handler(pat, passcode, allowed_file_keys,
                     return
                 processed_ids.add(comment_id)
 
-            audit_id = new_audit_id()
-            audit, reason = _build_audit(
-                payload, comment_id, pat, allowed_file_keys,
-                trigger_config, audit_id, limiter=limiter,
-            )
+            tracer = get_tracer()
+            with tracer.start_as_current_span('webhook.receive', attributes={
+                'figma.file_key': file_key,
+                'figma.comment_id': str(comment_id),
+            }):
+              audit_id = new_audit_id()
+              audit, reason = _build_audit(
+                  payload, comment_id, pat, allowed_file_keys,
+                  trigger_config, audit_id, limiter=limiter,
+              )
 
-            if audit is None:
-                logger.debug('skip', extra={'reason': reason})
-                self._respond(200, reason)
-                return
+              if audit is None:
+                  logger.debug('skip', extra={'reason': reason})
+                  self._respond(200, reason)
+                  return
 
-            save_processed(processed_ids)
+              save_processed(processed_ids)
 
-            trigger_kw = audit.trigger_match.trigger.keyword
+              trigger_kw = audit.trigger_match.trigger.keyword
 
-            # Temporarily set context so the ack post + enqueue log lines
-            # carry the new audit_id. Cleared on next request.
-            set_audit_context(
-                audit=audit_id,
-                trigger=trigger_kw,
-                node=audit.comment.node_id,
-                file=file_key,
-            )
+              # Temporarily set context so the ack post + enqueue log lines
+              # carry the new audit_id. Cleared on next request.
+              set_audit_context(
+                  audit=audit_id,
+                  trigger=trigger_kw,
+                  node=audit.comment.node_id,
+                  file=file_key,
+              )
 
-            logger.info(
-                '\U0001f4ac trigger matched',
-                extra={'user': audit.comment.user_handle},
-            )
+              logger.info(
+                  '\U0001f4ac trigger matched',
+                  extra={'user': audit.comment.user_handle},
+              )
 
-            ahead = work_queue.depth
-            if ahead == 0:
-                queue_msg = (
-                    f'\u23f3 {trigger_kw.lstrip("@")} audit queued '
-                    f'\u2014 starting shortly\u2026'
-                )
-            else:
-                queue_msg = (
-                    f'\u23f3 {trigger_kw.lstrip("@")} audit queued '
-                    f'({ahead} ahead of you)\u2026'
-                )
+              ahead = work_queue.depth
+              if ahead == 0:
+                  queue_msg = (
+                      f'\u23f3 {trigger_kw.lstrip("@")} audit queued '
+                      f'\u2014 starting shortly\u2026'
+                  )
+              else:
+                  queue_msg = (
+                      f'\u23f3 {trigger_kw.lstrip("@")} audit queued '
+                      f'({ahead} ahead of you)\u2026'
+                  )
 
-            ack_id = audit_service.post_ack(audit, queue_msg)
+              ack_id = audit_service.post_ack(audit, queue_msg)
 
-            trace_ctx = {}
-            try:
-                from opentelemetry.propagators.textmap import inject
-                inject(trace_ctx)
-            except ImportError:
-                pass
+              trace_ctx = {}
+              try:
+                  from opentelemetry.propagators.textmap import inject
+                  inject(trace_ctx)
+              except ImportError:
+                  pass
 
-            queued = QueuedItem(
-                audit=audit,
-                ack_id=ack_id,
-                audit_id=audit_id,
-                trace_context=trace_ctx,
-            )
-            work_queue.put(queued)
-            record_queue_change(1)
+              queued = QueuedItem(
+                  audit=audit,
+                  ack_id=ack_id,
+                  audit_id=audit_id,
+                  trace_context=trace_ctx,
+              )
+              work_queue.put(queued)
+              record_queue_change(1)
 
-            # Record initial displayed position so the updater only fires
-            # when the position actually changes.
-            ack_updater.track_initial(audit_id, position=ahead)
+              # Record initial displayed position so the updater only fires
+              # when the position actually changes.
+              ack_updater.track_initial(audit_id, position=ahead)
 
-            stats = work_queue.stats()
-            logger.info('queue.enqueued', extra={'depth': stats.depth})
+              stats = work_queue.stats()
+              logger.info('queue.enqueued', extra={'depth': stats.depth})
 
-            self._respond(200, 'Queued')
+              self._respond(200, 'Queued')
 
         def _respond(self, code, message):
             body = message.encode()


### PR DESCRIPTION
## Summary
- Add distributed tracing across the full audit lifecycle (webhook → queue → data fetch → AI call → reply) via OpenTelemetry spans
- New `figwatch/tracing.py` module mirrors the existing `metrics.py` pattern — noops when `OTEL_EXPORTER_OTLP_ENDPOINT` is unset
- `TracedThreadPoolExecutor` propagates trace context into parallel Figma API calls
- Trace context crosses the work queue boundary via `QueuedItem.trace_context` (inject/extract)
- Bump version to 1.3.3

Closes #39

## Spans
| Span | Location |
|------|----------|
| `audit` | `server.py` worker loop |
| `figma.fetch_data` | `figma.py:fetch_figma_data()` |
| `figma.screenshot` | `figma.py:fetch_screenshot()` |
| `figma.node_tree` | `figma.py:fetch_node_tree()` |
| `figma.api_call` | `figma.py:figma_get_retry()` |
| `skill.introspect` | `skills.py:_get_introspection()` |
| `skill.execute` | `skills.py:execute_skill()` |
| `figma.post_reply` | `services.py:post_reply()` |

## Test plan
- [x] 242 existing tests pass (tracing noops without endpoint)
- [x] Set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` with local collector, trigger audit, verify trace hierarchy
- [x] Verify `TracedThreadPoolExecutor` parents parallel spans under `figma.fetch_data`