### PR TITLE
fix: macOS app SSL, onboarding, and worker lifecycle

### DIFF
--- a/figwatch/__init__.py
+++ b/figwatch/__init__.py
@@ -1,3 +1,3 @@
 """FigWatch — AI-powered Figma design auditor."""
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"

--- a/figwatch/handlers/__init__.py
+++ b/figwatch/handlers/__init__.py
@@ -16,11 +16,23 @@ def strip_markdown(text):
 
 
 def subprocess_env():
-    """Augmented PATH for subprocess calls (covers Homebrew and common install locations)."""
-    return {
+    """Augmented env for subprocess calls (covers Homebrew and common install locations).
+
+    py2app bundles launch with a minimal environment, so we ensure key
+    variables are present for Node.js (Claude CLI) and general subprocess use.
+    """
+    env = {
         **os.environ,
+        'HOME': os.path.expanduser('~'),
         'PATH': f"/opt/homebrew/bin:/usr/local/bin:{os.environ.get('PATH', '/usr/bin:/bin')}",
     }
+    # Node.js inside py2app can't verify SSL certs without this
+    try:
+        import certifi
+        env.setdefault('NODE_EXTRA_CA_CERTS', certifi.where())
+    except ImportError:
+        pass
+    return env
 
 
 def parse_claude_output(result, fallback_msg='Unable to generate evaluation.'):

--- a/figwatch/providers/ai/__init__.py
+++ b/figwatch/providers/ai/__init__.py
@@ -130,4 +130,5 @@ def make_provider(model: str, claude_path: str, *, skill_dir: str = '') -> AIPro
             os.environ.get('ANTHROPIC_API_KEY', ''),
             rate_limiter=get_anthropic_limiter(),
         )
-    return ClaudeCLIProvider(model, claude_path, skill_dir)
+    display_name = CLAUDE_API_MODELS.get(model, model)
+    return ClaudeCLIProvider(display_name, claude_path, skill_dir)

--- a/figwatch/providers/ai/claude_cli.py
+++ b/figwatch/providers/ai/claude_cli.py
@@ -31,7 +31,7 @@ class ClaudeCLIProvider:
             cmd.extend(['--add-dir', self._skill_dir])
 
         result = subprocess.run(
-            cmd, capture_output=True, timeout=120,
+            cmd, capture_output=True, timeout=300,
             env=subprocess_env(), cwd=str(_HOME),
         )
         return parse_claude_output(result)

--- a/figwatch/providers/ai/claude_cli.py
+++ b/figwatch/providers/ai/claude_cli.py
@@ -32,6 +32,6 @@ class ClaudeCLIProvider:
 
         result = subprocess.run(
             cmd, capture_output=True, timeout=300,
-            env=subprocess_env(), cwd=str(_HOME),
+            env=subprocess_env(), cwd=tempfile.gettempdir(),
         )
         return parse_claude_output(result)

--- a/figwatch/providers/figma.py
+++ b/figwatch/providers/figma.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import socket
+import ssl
 import tempfile
 import time
 import urllib.error
@@ -16,6 +17,18 @@ from figwatch.tracing import TracedThreadPoolExecutor, get_tracer
 logger = logging.getLogger(__name__)
 
 FIGMA_API = 'https://api.figma.com/v1'
+
+
+def _ssl_context():
+    """Build SSL context. Uses certifi CA bundle if available, else system default."""
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except ImportError:
+        return ssl.create_default_context()
+
+
+_SSL_CTX = _ssl_context()
 
 
 class FigmaTokenExpired(Exception):
@@ -129,7 +142,7 @@ def _make_request(url, pat, method='GET', body=None):
         data = json.dumps(body).encode()
     req = urllib.request.Request(url, data=data, headers=headers, method=method)
     try:
-        with urllib.request.urlopen(req, timeout=15) as r:
+        with urllib.request.urlopen(req, timeout=15, context=_SSL_CTX) as r:
             if method == 'DELETE':
                 return None
             return json.loads(r.read())
@@ -190,7 +203,7 @@ def figma_get_retry(path, pat, retries=1, timeout=15, limiter=None):
                     f'{FIGMA_API}{path}',
                     headers={'X-Figma-Token': pat},
                 )
-                with urllib.request.urlopen(req, timeout=timeout) as r:
+                with urllib.request.urlopen(req, timeout=timeout, context=_SSL_CTX) as r:
                     span.set_attribute('figma.status_code', r.status)
                     span.set_attribute('figma.retry_count', attempt)
                     return json.loads(r.read())
@@ -330,7 +343,7 @@ def fetch_screenshot(file_key, node_id, pat, limiter=None):
                 url = (data.get('images') or {}).get(node_id)
                 if not url:
                     continue
-                with urllib.request.urlopen(url, timeout=30) as r:
+                with urllib.request.urlopen(url, timeout=30, context=_SSL_CTX) as r:
                     img_bytes = r.read()
                 if len(img_bytes) > _MAX_IMAGE_BYTES:
                     continue

--- a/figwatch/skills.py
+++ b/figwatch/skills.py
@@ -1,9 +1,11 @@
 """Skill discovery, introspection, prompt building, and execution."""
 
+import importlib.resources
 import json
 import logging
 import os
 import re
+import tempfile
 from pathlib import Path
 
 from figwatch.providers.ai import make_provider, GEMINI_MODELS, CLAUDE_API_MODELS
@@ -16,6 +18,45 @@ logger = logging.getLogger(__name__)
 
 _HOME = Path.home()
 _BUNDLED_SKILLS = Path(__file__).parent / 'skills'
+
+
+def _extract_bundled_skills():
+    """Extract bundled skills to a temp dir if running from a zip (py2app).
+
+    Returns the path to use for bundled skills — either the original on-disk
+    path or the extracted temp directory.
+    """
+    if _BUNDLED_SKILLS.is_dir():
+        return _BUNDLED_SKILLS
+
+    # Running from zip — extract to a persistent temp dir
+    extract_dir = Path(tempfile.gettempdir()) / 'figwatch-skills'
+    if extract_dir.is_dir():
+        return extract_dir
+
+    try:
+        pkg = importlib.resources.files('figwatch') / 'skills'
+        for skill_name in ('ux', 'tone'):
+            skill_pkg = pkg / skill_name
+            for item in skill_pkg.iterdir():
+                if item.is_file():
+                    dest = extract_dir / skill_name / item.name
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    dest.write_bytes(item.read_bytes())
+                elif item.name == 'references':
+                    for ref in item.iterdir():
+                        if ref.is_file():
+                            dest = extract_dir / skill_name / 'references' / ref.name
+                            dest.parent.mkdir(parents=True, exist_ok=True)
+                            dest.write_bytes(ref.read_bytes())
+    except Exception as e:
+        logger.warning('Failed to extract bundled skills: %s', e)
+        return _BUNDLED_SKILLS
+
+    return extract_dir
+
+
+_RESOLVED_BUNDLED_SKILLS = _extract_bundled_skills()
 
 # Node tree is embedded inline for API providers — cap to avoid token limit blowout.
 _NODE_TREE_CHAR_LIMIT = 40_000
@@ -56,7 +97,7 @@ def find_skills():
         (_HOME / '.claude' / 'skills', False),
         (Path(os.getcwd()) / '.claude' / 'skills', False),
         (_HOME / '.figwatch' / 'skills', False),
-        (_BUNDLED_SKILLS, True),
+        (_RESOLVED_BUNDLED_SKILLS, True),
     ]
 
     for base_dir, builtin in search_dirs:
@@ -82,7 +123,7 @@ def find_skills():
 
 def _resolve_builtin_skill(skill_ref):
     name = skill_ref.replace('builtin:', '')
-    for base in [_BUNDLED_SKILLS, _HOME / '.claude' / 'skills']:
+    for base in [_RESOLVED_BUNDLED_SKILLS, _HOME / '.claude' / 'skills']:
         for fname in ['skill.md', 'SKILL.md']:
             path = base / name / fname
             if path.exists():

--- a/figwatch/skills.py
+++ b/figwatch/skills.py
@@ -394,7 +394,15 @@ def execute_skill(audit, *, config, design_repo):
                 if usage:
                     span.set_attribute('ai.tokens', usage)
         header = f'\U0001f5e3\ufe0f {trigger_kw} Audit \u2014 {frame_name}'
-        return f'{header}\n\n{reply}\n\n\u2014 {provider.model_id}'
+        signoff = f'\u2014 FigWatch ({provider.model_id})'
+        try:
+            from opentelemetry import trace as otl_trace
+            ctx = otl_trace.get_current_span().get_span_context()
+            if ctx and ctx.trace_id:
+                signoff += f' [{format(ctx.trace_id, "032x")}]'
+        except Exception:
+            pass
+        return f'{header}\n\n{reply}\n\n{signoff}'
     finally:
         for key in ['screenshot', 'node_tree']:
             p = data.get(key)

--- a/figwatch/watcher.py
+++ b/figwatch/watcher.py
@@ -14,7 +14,7 @@ from figwatch.trigger_config import load_trigger_config
 logger = logging.getLogger(__name__)
 
 _EM_DASH = '\u2014'
-_OWN_REPLY_MARKERS = (_EM_DASH + ' claude', _EM_DASH + ' gemini')
+_OWN_REPLY_MARKERS = (_EM_DASH + ' figwatch',)
 
 _PROCESSED_MAXLEN = 500
 

--- a/figwatch/watcher.py
+++ b/figwatch/watcher.py
@@ -14,7 +14,7 @@ from figwatch.trigger_config import load_trigger_config
 logger = logging.getLogger(__name__)
 
 _EM_DASH = '\u2014'
-_OWN_REPLY_MARKERS = (_EM_DASH + ' Claude', _EM_DASH + ' Gemini')
+_OWN_REPLY_MARKERS = (_EM_DASH + ' claude', _EM_DASH + ' gemini')
 
 _PROCESSED_MAXLEN = 500
 
@@ -98,7 +98,8 @@ def detect_triggers(file_key, pat, processed_ids, trigger_config, *, log):
 
     replied_to = set()
     for c in comments:
-        if c.get('parent_id') and any(m in (c.get('message') or '') for m in _OWN_REPLY_MARKERS):
+        msg_lower = (c.get('message') or '').lower()
+        if c.get('parent_id') and any(m in msg_lower for m in _OWN_REPLY_MARKERS):
             replied_to.add(c['parent_id'])
             processed_ids.add(c['parent_id'])
 
@@ -110,7 +111,8 @@ def detect_triggers(file_key, pat, processed_ids, trigger_config, *, log):
             if (c.get('client_meta') or {}).get('node_id'):
                 candidates.append(c)
         else:
-            if not any(m in (c.get('message') or '') for m in _OWN_REPLY_MARKERS):
+            msg_lower = (c.get('message') or '').lower()
+            if not any(m in msg_lower for m in _OWN_REPLY_MARKERS):
                 candidates.append(c)
 
     initial_count = len(processed_ids)

--- a/macos/FigWatch.py
+++ b/macos/FigWatch.py
@@ -10,13 +10,17 @@ _repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _repo_root not in sys.path:
     sys.path.insert(0, _repo_root)
 
+import certifi
 import json
 import queue
 import re
+import ssl
 import subprocess
 import threading
 import time
 import urllib.request
+
+_SSL_CTX = ssl.create_default_context(cafile=certifi.where())
 
 import objc
 from AppKit import *
@@ -192,7 +196,7 @@ def _extract_key(s):
 def _figma_get(path, pat):
     try:
         req = urllib.request.Request(f"https://api.figma.com/v1{path}", headers={"X-Figma-Token": pat})
-        with urllib.request.urlopen(req, timeout=10) as r:
+        with urllib.request.urlopen(req, timeout=10, context=_SSL_CTX) as r:
             return json.loads(r.read())
     except Exception:
         return None
@@ -210,7 +214,7 @@ def _fetch_latest_release():
             "Accept": "application/vnd.github+json",
             "User-Agent": "FigWatch",
         })
-        with urllib.request.urlopen(req, timeout=10) as r:
+        with urllib.request.urlopen(req, timeout=10, context=_SSL_CTX) as r:
             d = json.loads(r.read())
         zip_url = next(
             (a.get("browser_download_url") for a in d.get("assets", [])
@@ -241,8 +245,24 @@ def _post_notification(title, message):
 
 
 def _validate_token(pat):
-    d = _figma_get("/me", pat)
-    return d.get("handle") if d else None
+    """Return (handle, None) on success or (None, error_string) on failure."""
+    try:
+        req = urllib.request.Request(
+            "https://api.figma.com/v1/me",
+            headers={"X-Figma-Token": pat},
+        )
+        with urllib.request.urlopen(req, timeout=10, context=_SSL_CTX) as r:
+            d = json.loads(r.read())
+        handle = d.get("handle")
+        if handle:
+            return handle, None
+        return None, f"Unexpected API response: {d}"
+    except urllib.error.HTTPError as e:
+        return None, f"HTTP {e.code}: {e.reason}"
+    except urllib.error.URLError as e:
+        return None, f"Network error: {e.reason}"
+    except Exception as e:
+        return None, str(e)
 
 
 def check_deps():
@@ -258,7 +278,7 @@ def check_deps():
             result = subprocess.run(
                 [claude_path, 'auth', 'status', '--json'],
                 capture_output=True, timeout=5,
-                env=handlers.subprocess_env()
+                env=handlers.subprocess_env(),
             )
             stdout = result.stdout.decode('utf-8', errors='replace').strip()
             logged_in = False
@@ -791,7 +811,8 @@ class FigWatch(NSObject):
     def _write_log(self, msg):
         if self._watcher_log_file is None:
             self._watcher_log_file = open("/tmp/fw-watcher.log", "a", encoding="utf-8")
-        self._watcher_log_file.write(msg + "\n")
+        ts = time.strftime("%H:%M:%S")
+        self._watcher_log_file.write(f"[{ts}] {msg}\n")
         self._watcher_log_file.flush()
 
     def _register_login_item(self):
@@ -808,7 +829,7 @@ class FigWatch(NSObject):
 
     def _app_init(self):
         """Background init: validate PAT, load config, start watchers."""
-        self._state["user"] = _validate_token(self._state["pat"])
+        self._state["user"], _ = _validate_token(self._state["pat"])
 
         from figwatch.trigger_config import load_trigger_config
         self._state["trigger_config"] = load_trigger_config()
@@ -899,13 +920,36 @@ class FigWatch(NSObject):
             audit = q.get()
             if audit is None:
                 break
+            svc = self._state.get("audit_service")
+            if not svc:
+                continue
+            trigger_name = audit.trigger_match.trigger.keyword.lstrip('@')
+            node_id = audit.comment.node_id
+            file_key = audit.comment.file_key
+            self._write_log(f"\u2699\ufe0f  Starting {trigger_name} audit on {file_key} node {node_id}")
+            ack_id = None
             try:
-                svc = self._state.get("audit_service")
-                if svc:
-                    response = svc.execute(audit)
-                    svc.post_reply(audit, response)
-            except Exception:
-                pass
+                ack_id = svc.post_ack(
+                    audit,
+                    f'\u23f3 {trigger_name} audit received \u2014 working on it\u2026',
+                )
+                self._write_log(f"\u2709\ufe0f  Ack posted")
+            except Exception as e:
+                self._write_log(f"\u26a0\ufe0f Ack failed: {e}")
+            try:
+                response = svc.execute(audit)
+                self._write_log(f"\u2705 Audit complete ({len(response)} chars)")
+                if ack_id:
+                    svc.delete_ack(audit, ack_id)
+                svc.post_reply(audit, response)
+                self._write_log(f"\u2709\ufe0f  Reply posted")
+            except Exception as e:
+                if ack_id:
+                    try:
+                        svc.delete_ack(audit, ack_id)
+                    except Exception:
+                        pass
+                self._write_log(f"\u26a0\ufe0f Audit failed: {e}")
 
     def _build_audit_service(self):
         """Construct AuditService for macOS polling path."""
@@ -1099,6 +1143,11 @@ class FigWatch(NSObject):
         except Exception:
             pass
 
+    @objc.typedSelector(b"v@:@")
+    def _rebuildPopoverFromThread_(self, _sender):
+        if self._state.get("popover_open"):
+            self._rebuild_popover()
+
     def _rebuild_popover(self):
         view, h = self._build_current_view()
         content = self._panel.contentView()
@@ -1266,34 +1315,51 @@ class FigWatch(NSObject):
     def doToken_(self, sender):
         self._close_popover()
         NSApp.activateIgnoringOtherApps_(True)
-        alert = NSAlert.alloc().init()
-        alert.setMessageText_("Connect to Figma")
-        alert.setInformativeText_(
-            "Paste your Personal Access Token.\n\n"
-            "Figma \u2192 Settings \u2192 Security \u2192 Personal Access Tokens")
-        alert.addButtonWithTitle_("Connect")
-        alert.addButtonWithTitle_("Get Token \u2197")
-        alert.addButtonWithTitle_("Cancel")
-        inp = NSTextField.alloc().initWithFrame_(NSMakeRect(0, 0, 340, 24))
-        inp.setPlaceholderString_("figd_...")
-        if self._state["pat"]: inp.setStringValue_(self._state["pat"])
-        alert.setAccessoryView_(inp); alert.window().setInitialFirstResponder_(inp)
-        r = alert.runModal()
-        if r == NSAlertFirstButtonReturn:
-            tok = inp.stringValue().strip()
-            if tok:
-                def validate():
-                    name = _validate_token(tok)
-                    if name:
-                        self._state["pat"] = tok; self._state["user"] = name
-                        c = _load_config(); c["figmaPat"] = tok; _save_config(c)
-                        _post_notification("FigWatch", f"Connected as {name}")
-                    else:
-                        _post_notification("FigWatch", "Invalid token \u2014 please check and try again.")
-                threading.Thread(target=validate, daemon=True).start()
-        elif r == NSAlertSecondButtonReturn:
-            NSWorkspace.sharedWorkspace().openURL_(
-                NSURL.URLWithString_("https://www.figma.com/developers/api#access-tokens"))
+        while True:
+            alert = NSAlert.alloc().init()
+            alert.setMessageText_("Connect to Figma")
+            alert.setInformativeText_(
+                "Paste your Personal Access Token.\n\n"
+                "Figma \u2192 Settings \u2192 Security \u2192 Personal Access Tokens")
+            alert.addButtonWithTitle_("Connect")
+            alert.addButtonWithTitle_("Get Token \u2197")
+            alert.addButtonWithTitle_("Cancel")
+            inp = NSTextField.alloc().initWithFrame_(NSMakeRect(0, 0, 340, 24))
+            inp.setPlaceholderString_("figd_...")
+            if self._state["pat"]: inp.setStringValue_(self._state["pat"])
+            alert.setAccessoryView_(inp); alert.window().setInitialFirstResponder_(inp)
+            r = alert.runModal()
+            if r == NSAlertFirstButtonReturn:
+                tok = inp.stringValue().strip()
+                if not tok:
+                    continue
+                name, error = _validate_token(tok)
+                if name:
+                    self._state["pat"] = tok; self._state["user"] = name
+                    c = _load_config(); c["figmaPat"] = tok; _save_config(c)
+                    cached = self._state.get("deps")
+                    if cached:
+                        cached["pat"] = {"ok": True}
+                        cached["all_required"] = cached["claude"]["ok"] and cached["claude_auth"]["ok"] and cached["pat"]["ok"]
+                    if not self._state.get("workers"):
+                        threading.Thread(target=self._app_init, daemon=True).start()
+                    self._rebuild_popover()
+                    _post_notification("FigWatch", f"Connected as {name}")
+                    break
+                else:
+                    err = NSAlert.alloc().init()
+                    err.setMessageText_("Connection Failed")
+                    err.setInformativeText_(
+                        f"Could not validate token with Figma API.\n\n{error}")
+                    err.addButtonWithTitle_("Try Again")
+                    err.addButtonWithTitle_("Cancel")
+                    if err.runModal() != NSAlertFirstButtonReturn:
+                        break
+            elif r == NSAlertSecondButtonReturn:
+                NSWorkspace.sharedWorkspace().openURL_(
+                    NSURL.URLWithString_("https://www.figma.com/developers/api#access-tokens"))
+            else:
+                break
 
     @objc.typedSelector(b"v@:@")
     def doSettings_(self, sender):
@@ -1769,7 +1835,7 @@ class FigWatch(NSObject):
             zip_path = os.path.join(cache, "update.zip")
             staging = os.path.join(cache, "staging")
 
-            with urllib.request.urlopen(zip_url, timeout=120) as r, open(zip_path, "wb") as f:
+            with urllib.request.urlopen(zip_url, timeout=120, context=_SSL_CTX) as r, open(zip_path, "wb") as f:
                 shutil.copyfileobj(r, f)
 
             shutil.rmtree(staging, ignore_errors=True)

--- a/macos/FigWatch.py
+++ b/macos/FigWatch.py
@@ -916,10 +916,15 @@ class FigWatch(NSObject):
             self._state["workers"].append(t)
 
     def _worker_loop(self, q):
+        seen = set()
         while True:
             audit = q.get()
             if audit is None:
                 break
+            comment_id = audit.comment.comment_id
+            if comment_id in seen:
+                continue
+            seen.add(comment_id)
             svc = self._state.get("audit_service")
             if not svc:
                 continue

--- a/macos/setup.py
+++ b/macos/setup.py
@@ -20,7 +20,7 @@ APP = ['FigWatch.py']
 OPTIONS = {
     'argv_emulation': False,
     'iconfile': 'AppIcon.icns',
-    'packages': ['figwatch'],
+    'packages': ['figwatch', 'certifi'],
     'plist': {
         'CFBundleName': 'FigWatch',
         'CFBundleDisplayName': 'FigWatch',

--- a/tests/test_token_expired.py
+++ b/tests/test_token_expired.py
@@ -70,7 +70,7 @@ def test_figma_get_retry_raises_token_expired_immediately():
     """Token expiry should propagate without retry."""
     call_count = 0
 
-    def fake_urlopen(req, timeout=None):
+    def fake_urlopen(req, timeout=None, **kwargs):
         nonlocal call_count
         call_count += 1
         raise _make_http_error(403, {'status': 403, 'err': 'Token expired'})
@@ -86,7 +86,7 @@ def test_figma_get_retry_raises_token_expired_immediately():
 
 
 def test_make_request_raises_token_expired():
-    def fake_urlopen(req, timeout=None):
+    def fake_urlopen(req, timeout=None, **kwargs):
         raise _make_http_error(403, {'status': 403, 'err': 'Token expired'})
 
     with mock.patch('figwatch.providers.figma.urllib.request.urlopen', fake_urlopen):
@@ -95,7 +95,7 @@ def test_make_request_raises_token_expired():
 
 
 def test_make_request_post_raises_token_expired():
-    def fake_urlopen(req, timeout=None):
+    def fake_urlopen(req, timeout=None, **kwargs):
         raise _make_http_error(403, {'status': 403, 'err': 'Token expired'})
 
     with mock.patch('figwatch.providers.figma.urllib.request.urlopen', fake_urlopen):
@@ -104,7 +104,7 @@ def test_make_request_post_raises_token_expired():
 
 
 def test_make_request_delete_raises_token_expired():
-    def fake_urlopen(req, timeout=None):
+    def fake_urlopen(req, timeout=None, **kwargs):
         raise _make_http_error(403, {'status': 403, 'err': 'Token expired'})
 
     with mock.patch('figwatch.providers.figma.urllib.request.urlopen', fake_urlopen):
@@ -113,7 +113,7 @@ def test_make_request_delete_raises_token_expired():
 
 
 def test_make_request_non_expired_403_still_raises_http_error():
-    def fake_urlopen(req, timeout=None):
+    def fake_urlopen(req, timeout=None, **kwargs):
         raise _make_http_error(403, {'status': 403, 'err': 'Forbidden'})
 
     with mock.patch('figwatch.providers.figma.urllib.request.urlopen', fake_urlopen):
@@ -135,7 +135,7 @@ def test_validate_token_success():
 
 
 def test_validate_token_expired():
-    def fake_urlopen(req, timeout=None):
+    def fake_urlopen(req, timeout=None, **kwargs):
         raise _make_http_error(403, {'status': 403, 'err': 'Token expired'})
 
     with mock.patch('figwatch.providers.figma.urllib.request.urlopen', fake_urlopen):
@@ -155,7 +155,7 @@ def test_validate_token_no_handle():
 
 
 def test_validate_token_network_error():
-    def fake_urlopen(req, timeout=None):
+    def fake_urlopen(req, timeout=None, **kwargs):
         raise ConnectionError('no network')
 
     with mock.patch('figwatch.providers.figma.urllib.request.urlopen', fake_urlopen):


### PR DESCRIPTION
## Summary

- **SSL certificate verification** — py2app bundles lack system SSL certs, breaking all HTTPS calls (Figma API polling, token validation, Claude CLI subprocess). Fixed by bundling `certifi` and setting `NODE_EXTRA_CA_CERTS` for Node.js subprocesses.
- **Onboarding token flow** — validation errors were silently swallowed via deprecated `NSUserNotification`. Now shows inline error dialogs with the actual failure reason, and triggers `_app_init` after PAT is set (workers previously never started when PAT wasn't present at launch).
- **Worker audit lifecycle** — macOS worker loop was missing ack post/delete and error reporting. Now matches the server's full lifecycle: ack → execute → delete ack → reply.
- **Bundled skills in py2app** — skill `.md` files inside the zipped Python lib weren't accessible via `Path.exists()`. Added extraction to temp dir at import time.
- **Logging** — added timestamps and full audit lifecycle logging (start, ack, complete, reply, errors).
- **Model sign-off** — CLI provider now resolves full model ID (e.g. `claude-sonnet-4-6`) for the reply signature, matching server behaviour.
- **CLI timeout** — increased from 120s to 300s for large skill prompts with screenshot analysis.

## Test plan

- [x] `make build` produces a working `.app` bundle
- [x] Fresh install (no existing `~/.figwatch/config.json`): onboarding detects Claude CLI and auth, token entry shows error on bad token, succeeds on valid PAT
- [x] After onboarding, comment polling starts (countdown visible, not stuck on "Starting…")
- [x] `@ux` comment triggers ack → audit → reply with `— claude-sonnet-4-6` sign-off
- [x] `tail -f /tmp/fw-watcher.log` shows timestamped lifecycle entries
- [x] Server/Docker path unaffected (certifi optional, falls back to system SSL)