### PR TITLE
fix: preserve executable permissions in release zip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,12 +78,16 @@ jobs:
       - name: Verify app bundle exists
         run: test -d macos/dist/FigWatch.app
 
-      - name: Upload app bundle
+      - name: Zip app bundle (ditto preserves permissions)
+        if: github.event_name == 'push'
+        run: ditto -c -k --keepParent macos/dist/FigWatch.app macos/dist/FigWatch.zip
+
+      - name: Upload app zip
         if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
-          name: FigWatch.app
-          path: macos/dist/FigWatch.app
+          name: FigWatch.zip
+          path: macos/dist/FigWatch.zip
           retention-days: 1
 
   check-version:
@@ -171,14 +175,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Download app bundle
+      - name: Download app zip
         uses: actions/download-artifact@v4
         with:
-          name: FigWatch.app
-          path: FigWatch.app
-
-      - name: Zip app bundle
-        run: zip -r FigWatch.zip FigWatch.app
+          name: FigWatch.zip
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2

--- a/figwatch/__init__.py
+++ b/figwatch/__init__.py
@@ -1,3 +1,3 @@
 """FigWatch — AI-powered Figma design auditor."""
 
-__version__ = "1.3.4"
+__version__ = "1.3.5"


### PR DESCRIPTION
## Summary

- Use `ditto -c -k` in the macOS build job to create the zip — preserves Unix permissions and resource forks
- Release job downloads the pre-built zip directly instead of re-zipping with `zip -r` which strips `+x` from binaries
- Previously, downloaded `.app` from releases wouldn't open because `Contents/MacOS/FigWatch` and `Contents/MacOS/python` lost their executable bit
- Bump version to 1.3.5

## Test plan

- [x] CI macOS build job creates zip with `ditto`
- [ ] Release job downloads and attaches pre-built zip
- [ ] Downloaded zip extracts with executable permissions intact (`ls -la Contents/MacOS/`)
- [ ] App opens without `xattr -cr` workaround (right-click → Open for unsigned)