### PR TITLE
docs: add macOS install instructions to GitHub releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,4 +186,13 @@ jobs:
           tag_name: v${{ needs.check-version.outputs.version }}
           name: FigWatch v${{ needs.check-version.outputs.version }}
           generate_release_notes: true
+          append_body: true
           files: FigWatch.zip
+          body: |
+            ## Install
+
+            1. Download **FigWatch.zip** below
+            2. Extract and move **FigWatch.app** to `/Applications`
+            3. **Right-click → Open** on first launch (required for unsigned apps)
+
+            > If macOS still blocks the app, run: `xattr -cr /Applications/FigWatch.app`

--- a/figwatch/__init__.py
+++ b/figwatch/__init__.py
@@ -1,3 +1,3 @@
 """FigWatch — AI-powered Figma design auditor."""
 
-__version__ = "1.3.5"
+__version__ = "1.3.6"


### PR DESCRIPTION
## Summary

- Append install instructions to every GitHub release via `append_body`
- Steps: download zip, extract to Applications, right-click → Open
- Includes `xattr -cr` fallback for stubborn Gatekeeper cases
- Auto-generated changelog from `generate_release_notes` remains above

## Test plan

- [ ] Merge and tag a release to verify install section appears below changelog